### PR TITLE
feat(ops): Micrometer(JMX) 기반 모니터링 베이스라인 및 운영 가이드

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,22 @@
 3. [템플릿 구성 및 환경설정](https://www.egovframe.go.kr/wiki/doku.php?id=egovframework:let4:configration) 문서를 참고하여 템플릿 환경설정을 수행한다.
 
 4. 실행할 프로젝트를 마우스 우클릭하고 **Run As > Run on Server** 를 선택한다.
+
+## 운영 가시성(Observability) 베이스라인
+
+이 템플릿은 **Micrometer(JMX/내부용)** 기반의 **최소 모니터링**을 제공합니다.
+
+- 기본 제공 메트릭: JVM 메모리/스레드/클래스로더/CPU
+- **보안 기본값**: 외부 노출 엔드포인트 없음(JMX로 내부 확인)
+- 로컬 확인: VisualVM 등으로 JVM 프로세스 JMX 접속 후 Micrometer 메트릭 확인
+
+### 로드맵/연계
+- 이 PR은 개발환경/테스트 표준화 작업과 연계된 **3단계 개선** 중 ③ 단계입니다.
+  - ① DevContainer + 원클릭(5분 셋업): #58  ← DX 표준 확립
+  - ② Testcontainers + GitHub Actions CI: #59  ← 품질/재현성 표준 확립  
+  - ③ Observability(본 PR): 운영/모니터링 표준의 최소선 제공
+
+### 보안/운영 권장
+- 기본은 **JMX만 사용**(외부 노출 없음)
+- 프로덕션에서는 게이트웨이/방화벽 레벨로 내부망 접근만 허용
+- 추후 Spring Boot 전환 시 Actuator로 자연스럽게 마이그레이션(별도 PR)

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,34 @@
 			<version>${spring.maven.artifact.version}</version>
 			<scope>test</scope>
 		</dependency>
+		
+		<!-- metrics -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+			<version>1.12.5</version>
+		</dependency>
+		
+		<!-- JMX registry for Micrometer -->
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-jmx</artifactId>
+			<version>1.12.5</version>
+		</dependency>
+
+		<!-- JMX export helpers (Spring Framework) -->
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+			<version>${spring.maven.artifact.version}</version>
+		</dependency>
+
+		<!-- JSON 응답용 -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.17.1</version>
+		</dependency>
 	</dependencies>
 
     <build>

--- a/src/main/java/egovframework/com/config/ObservabilityConfig.java
+++ b/src/main/java/egovframework/com/config/ObservabilityConfig.java
@@ -1,0 +1,37 @@
+package egovframework.com.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.jmx.JmxConfig;
+import io.micrometer.jmx.JmxMeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.*;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObservabilityConfig {
+
+    @Bean
+    public JmxConfig jmxConfig() {
+        // null 리턴은 기본값 사용 의미
+        return new JmxConfig() {
+            @Override 
+            public String get(String k) { 
+                return null; 
+            }
+        };
+    }
+
+    @Bean
+    public MeterRegistry meterRegistry(JmxConfig jmxConfig) {
+        MeterRegistry registry = new JmxMeterRegistry(jmxConfig, io.micrometer.core.instrument.Clock.SYSTEM);
+        
+        // JVM 메트릭 바인더 등록
+        new ClassLoaderMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        
+        return registry;
+    }
+}

--- a/src/main/resources/egovframework/spring/com/context-metrics.xml
+++ b/src/main/resources/egovframework/spring/com/context-metrics.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context.xsd">
+
+  <!-- JMX-enabled Micrometer 설정 (Java Config 사용) -->
+  <context:component-scan base-package="egovframework.com.config" />
+  
+</beans>


### PR DESCRIPTION
 ## 요약

  - Micrometer(JMX) + JVM 메트릭 바인더 등록 (JMX/내부 확인)
  - 외부 엔드포인트 노출 없음(보안 보수적), 운영 가이드 문서화

  ## 변경사항

  - **pom.xml**: micrometer-core, micrometer-registry-jmx 추가 (Jackson은 중복 시 생략)
  - **src/main/java/egovframework/com/config/ObservabilityConfig.java**: JMX 메트릭 등록 Bean 구성

  - **src/main/resources/egovframework/spring/com/context-metrics.xml**: config 패키지 컴포넌트
  스캔
  - **README.md**: 운영 가시성 섹션(보안/운영 권장/로드맵) 추가

  ## How to verify

  - 로컬 기동 후 VisualVM(JMX)로 프로세스 접속 → JVM/Micrometer 메트릭 노출 확인
  - 기존 기능/테스트에 영향 없음(CI는 #59에서 보장)

  ## Relationship

  ① **DX(DevContainer + 원클릭)** – #58: 누구나 5분 내 개발환경 구동. 본 PR은 실행 후 운영 가시성
  제공(https://github.com/eGovFramework/egovframe-enterprise-business-template/pull/58)

  ② **품질(Testcontainers + CI)** – #59: 재현 가능한 테스트/커버리지. 본 PR은 런타임 모니터링
  기본선을 제공.(https://github.com/eGovFramework/egovframe-enterprise-business-template/pull/59)

  ## Security

  - 외부 노출 엔드포인트 없음(JMX만)
  - 프로덕션에서는 내부망에서만 접근(게이트웨이/방화벽/ACL로 제한)

  ## Future work

  - Spring Boot 전환 시 Actuator로 마이그레이션(health/readiness/metrics 표준화)
  - DB/외부연계 HealthIndicator(내부용) 추가는 별도 PR로 제안

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
