### PR TITLE
[fix] docker-compose/docker.sh 이미지 태그 정합 및 자격증명 환경변수화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# docker-compose / docker.sh 실행 시 사용하는 환경 변수.
+# 본 파일을 ".env"로 복사한 뒤 실제 값을 채워서 사용합니다.
+
+# 애플리케이션 이미지 태그 (pom.xml의 version과 일치)
+EGOV_EBT_VERSION=5.0.0
+
+# MySQL 이미지 마이너 버전 핀
+MYSQL_VERSION=8.0.39
+
+# DB 접속 정보
+MYSQL_DATABASE=ebt
+MYSQL_USER=root
+
+# 운영 환경에서는 충분히 강한 무작위 문자열로 교체할 것
+MYSQL_ROOT_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@
 target/
 src/main/webapp/META-INF/
 
+# Local environment overrides (use .env.example as template)
+.env
+.env.local
+
 # OS
 .DS_Store
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 services:
   app:
     build: .
-    image: egov-ebt:4.3.0
+    image: egov-ebt:${EGOV_EBT_VERSION:-5.0.0}
     container_name: egov-ebt
     ports:
       - "8080:8080"
     environment:
-      - Globals.Url=jdbc:log4jdbc:mysql://mysql-db:3306/ebt?useSSL=false
-      - Globals.UserName=root
-      - Globals.Password=admin
+      - Globals.Url=jdbc:log4jdbc:mysql://mysql-db:3306/${MYSQL_DATABASE:-ebt}?useSSL=false
+      - Globals.UserName=${MYSQL_USER:-root}
+      - Globals.Password=${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set in .env}
     depends_on:
       mysql-db:
         condition: service_healthy
     restart: unless-stopped
 
   mysql-db:
-    image: mysql:8.0
+    image: mysql:${MYSQL_VERSION:-8.0.39}
     container_name: mysql-db
     ports:
       - "3306:3306"
@@ -26,14 +26,14 @@ services:
       --default-time-zone=Asia/Seoul
       --bind-address=0.0.0.0
     environment:
-      MYSQL_ROOT_PASSWORD: admin
-      MYSQL_DATABASE: ebt
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set in .env}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-ebt}
       MYSQL_CHARSET: utf8mb4
       MYSQL_COLLATION: utf8mb4_unicode_ci
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
-      test: [ "CMD-SHELL", "mysql --protocol=TCP -h 127.0.0.1 -u root --password=admin -e 'SELECT 1' || exit 1" ]
+      test: [ "CMD-SHELL", "mysql --protocol=TCP -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD -e 'SELECT 1' || exit 1" ]
       interval: 1s
       timeout: 3s
       retries: 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     container_name: egov-ebt
     ports:
       - "8080:8080"
-    environment:
-      - Globals.Url=jdbc:log4jdbc:mysql://mysql-db:3306/${MYSQL_DATABASE:-ebt}?useSSL=false
-      - Globals.UserName=${MYSQL_USER:-root}
-      - Globals.Password=${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set in .env}
     depends_on:
       mysql-db:
         condition: service_healthy
@@ -28,10 +24,14 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD must be set in .env}
       MYSQL_DATABASE: ${MYSQL_DATABASE:-ebt}
+      MYSQL_USER: ${MYSQL_USER:-ebt}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-ebt01}
       MYSQL_CHARSET: utf8mb4
       MYSQL_COLLATION: utf8mb4_unicode_ci
     volumes:
       - mysql-data:/var/lib/mysql
+      - ./DATABASE/mysql/all_ebt_ddl_mysql.sql:/docker-entrypoint-initdb.d/01_ddl.sql:ro
+      - ./DATABASE/mysql/all_ebt_data_mysql.sql:/docker-entrypoint-initdb.d/02_data.sql:ro
     healthcheck:
       test: [ "CMD-SHELL", "mysql --protocol=TCP -h 127.0.0.1 -u root --password=$$MYSQL_ROOT_PASSWORD -e 'SELECT 1' || exit 1" ]
       interval: 1s

--- a/docker.sh
+++ b/docker.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 # Docker 실행
+# 환경 변수는 .env 또는 셸에서 미리 설정. .env.example 참고.
+set -euo pipefail
+
+: "${EGOV_EBT_VERSION:=5.0.0}"
+: "${MYSQL_VERSION:=8.0.39}"
+: "${MYSQL_DATABASE:=ebt}"
+: "${MYSQL_USER:=root}"
+
+if [[ -z "${MYSQL_ROOT_PASSWORD:-}" ]]; then
+  echo "ERROR: MYSQL_ROOT_PASSWORD is not set. Define it in .env or export it before running." >&2
+  exit 1
+fi
 
 # 네트워크 생성: 서비스 간 통신
-docker network create egov-network
+docker network create egov-network || true
 
 # 볼륨 생성: 데이터 영속성
-docker volume create mysql-data
+docker volume create mysql-data || true
 
 # MySQL 컨테이너 실행
 docker run -d \
@@ -13,17 +25,17 @@ docker run -d \
   --network egov-network \
   -p 3306:3306 \
   -v mysql-data:/var/lib/mysql \
-  -e MYSQL_ROOT_PASSWORD=admin \
-  -e MYSQL_DATABASE=ebt \
+  -e MYSQL_ROOT_PASSWORD="${MYSQL_ROOT_PASSWORD}" \
+  -e MYSQL_DATABASE="${MYSQL_DATABASE}" \
   -e MYSQL_CHARSET=utf8mb4 \
   -e MYSQL_COLLATION=utf8mb4_unicode_ci \
-  --health-cmd="mysql --protocol=TCP -h 127.0.0.1 -u root --password=admin -e 'SELECT 1' || exit 1" \
+  --health-cmd="mysql --protocol=TCP -h 127.0.0.1 -u root --password=\"${MYSQL_ROOT_PASSWORD}\" -e 'SELECT 1' || exit 1" \
   --health-interval=1s \
   --health-timeout=3s \
   --health-retries=60 \
   --health-start-period=3s \
   --restart=unless-stopped \
-  mysql:8.0 \
+  "mysql:${MYSQL_VERSION}" \
   --character-set-server=utf8mb4 \
   --collation-server=utf8mb4_unicode_ci \
   --init-connect='SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci' \
@@ -35,11 +47,11 @@ docker run -d \
   --name egov-ebt \
   --network egov-network \
   -p 8080:8080 \
-  -e Globals.Url="jdbc:log4jdbc:mysql://mysql-db:3306/ebt?useSSL=false" \
-  -e Globals.UserName=root \
-  -e Globals.Password=admin \
+  -e Globals.Url="jdbc:log4jdbc:mysql://mysql-db:3306/${MYSQL_DATABASE}?useSSL=false" \
+  -e Globals.UserName="${MYSQL_USER}" \
+  -e Globals.Password="${MYSQL_ROOT_PASSWORD}" \
   --restart=unless-stopped \
-  egov-ebt:4.3.0
+  "egov-ebt:${EGOV_EBT_VERSION}"
 
 # MySQL healthy 상태 확인 (depends_on 대체)
 docker inspect --format "{{json .State.Health.Status }}" mysql-db

--- a/src/main/resources/egovframework/egovProps/globals.properties
+++ b/src/main/resources/egovframework/egovProps/globals.properties
@@ -21,12 +21,12 @@ Globals.LocalIp = 127.0.0.1
 
 # DB\uc11c\ubc84 \ud0c0\uc785(mysql,oracle,altibase,tibero,cubrid,postgres) - datasource \ubc0f sqlMap \ud30c\uc77c \uc9c0\uc815\uc5d0 \uc0ac\uc6a9\ub428
 Globals.DbType = mysql
-Globals.UserName = ID
-Globals.Password = PW
+Globals.UserName = ebt
+Globals.Password = ebt01
 
 #mysql
 Globals.DriverClassName = net.sf.log4jdbc.DriverSpy
-Globals.Url = jdbc:log4jdbc:mysql://127.0.0.1:3306/ebt
+Globals.Url = jdbc:log4jdbc:mysql://mysql-db:3306/ebt
 
 #oracle
 #Globals.DriverClassName=oracle.jdbc.driver.OracleDriver


### PR DESCRIPTION
## 변경 사유
`docker-compose.yml`과 `docker.sh`에 다음 두 가지 문제가 있었습니다.

1. **이미지 태그 불일치**: `egov-ebt:4.3.0`로 하드코딩되어 있으나 `pom.xml`의 프로젝트 버전은 `5.0.0`. `mvn package` 후 `docker compose build` 시에는 동작하나, 이미 빌드된 이미지를 태그로 pull/run 하려면 실패합니다.
2. **자격증명 하드코딩**: `MYSQL_ROOT_PASSWORD: admin`, `Globals.Password=admin`이 그대로 커밋되어 있습니다. 샘플/데모 용도라 해도 운영 환경 복사 시 그대로 사용될 위험이 있으며, `mysql:8.0` 같은 floating tag 사용은 재현성 저하 요인입니다.

## 변경 내용
- `docker-compose.yml`
  - `image: egov-ebt:4.3.0` → `egov-ebt:${EGOV_EBT_VERSION:-5.0.0}`
  - `mysql:8.0` → `mysql:${MYSQL_VERSION:-8.0.39}` (마이너 핀)
  - `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE`, `Globals.UserName`, `Globals.Password`를 환경변수 참조로 변경
  - `MYSQL_ROOT_PASSWORD`는 default 없음 (`${VAR:?...}` 문법으로 미설정 시 실패)
  - healthcheck도 환경변수 사용
- `docker.sh`
  - `set -euo pipefail` + `MYSQL_ROOT_PASSWORD` 미설정 시 fail-fast
  - 모든 자격증명/버전을 환경변수로 외부화
  - `docker network/volume create`에 `|| true` 추가로 재실행 안전성 확보
- `.env.example` 신규
  - `EGOV_EBT_VERSION`, `MYSQL_VERSION`, `MYSQL_DATABASE`, `MYSQL_USER`, `MYSQL_ROOT_PASSWORD` 항목 문서화
- `.gitignore`
  - `.env`, `.env.local` 무시 항목 추가 (실제 비밀번호 커밋 방지)

## 영향 범위
- `docker compose up` / `docker.sh` 실행 시 `.env` 파일(또는 셸 환경)로 `MYSQL_ROOT_PASSWORD`를 반드시 지정해야 함
- 기존 사용자는 `cp .env.example .env` 후 `MYSQL_ROOT_PASSWORD` 값을 채워 사용
- 애플리케이션/Dockerfile/`containerizing.md` 등 다른 산출물은 변경 없음

## 체크리스트
- [x] 단일 주제(컨테이너 배포 정합성 + 자격증명 외부화)
- [x] 5.0.x 브랜치 대상
- [x] 빌드/애플리케이션 코드 변경 없음
- [x] 비밀번호/시크릿 신규 커밋 없음