### PR TITLE
[chore] Dockerfile builder 단계 의존성 캐시 분리

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.9-jdk-17 AS builder
 WORKDIR /build
-COPY . .
-RUN mvn clean package -DskipTests
+
+# Resolve dependencies first so subsequent rebuilds reuse the layer cache
+# whenever only application sources change.
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp clean package -DskipTests
 
 FROM tomcat:10.1-jre17
 WORKDIR /app


### PR DESCRIPTION
## 변경 사유
현재 builder 스테이지는 `COPY . .` 한 줄로 컨텍스트 전체를 한 번에 복사한 뒤 `mvn clean package`를 실행합니다. `src/` 한 줄만 바뀌어도 의존성 캐시 레이어가 무효화되어 매 빌드마다 Maven이 의존성을 처음부터 다시 받아옵니다.

## 변경 내용
- `# syntax=docker/dockerfile:1.7` 추가 (BuildKit cache mount 인식)
- builder 스테이지 분리
  - `COPY pom.xml ./` → `mvn -B -ntp dependency:go-offline` (의존성 그래프 해상)
  - `--mount=type=cache,target=/root/.m2`로 BuildKit 캐시 사용
  - `COPY src ./src` → 기존 `mvn ... clean package -DskipTests`
- 런타임 스테이지(`tomcat:10.1-jre17`, `JAVA_TOOL_OPTIONS`, `catalina.sh run`)는 미변경

## 영향 범위
- 최종 이미지/실행 동작 동일
- 의존성이 안 바뀐 rebuild에서 캐시 hit으로 빌드 시간 단축
- BuildKit이 활성화된 환경(`DOCKER_BUILDKIT=1` 또는 Docker 23+)에서 cache mount 효과 발휘
- 비 BuildKit 환경에서는 syntax 지시문이 무시되고 일반 multi-stage 빌드로 동작

## 체크리스트
- [x] 단일 주제 (Dockerfile 캐시 분리)
- [x] 5.0.x 브랜치 대상
- [x] 런타임 스테이지/실행 명령 미변경