### PR TITLE
[refactor][enterprise] sym/log/clg 접속로그 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sym/log/clg/service/impl/LoginLogMapper.java
+++ b/src/main/java/egovframework/let/sym/log/clg/service/impl/LoginLogMapper.java
@@ -2,16 +2,15 @@ package egovframework.let.sym.log.clg.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sym.log.clg.service.LoginLog;
-import jakarta.annotation.Resource;
 
 /**
- * 시스템 로그 관리를 위한 데이터 접근 클래스
+ * 접속로그 관리에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스개발팀 이삼섭
  * @since 2009.03.11
- * @version 1.0
+ * @version 2.0
  * @see
  *
  * <pre>
@@ -26,53 +25,38 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("loginLogDAO")
-public class LoginLogDAO {
-
-	@Resource(name = "loginLogMapper")
-	private LoginLogMapper loginLogMapper;
+@EgovMapper("loginLogMapper")
+public interface LoginLogMapper {
 
 	/**
 	 * 접속로그를 기록한다.
-	 *
 	 * @param loginLog LoginLog
-	 * @throws Exception
+	 * @exception Exception
 	 */
-	public void logInsertLoginLog(LoginLog loginLog) throws Exception {
-		loginLogMapper.logInsertLoginLog(loginLog);
-	}
+	void logInsertLoginLog(LoginLog loginLog) throws Exception;
 
 	/**
 	 * 접속로그를 조회한다.
-	 *
 	 * @param loginLog LoginLog
 	 * @return LoginLog
-	 * @throws Exception
+	 * @exception Exception
 	 */
-	public LoginLog selectLoginLog(LoginLog loginLog) throws Exception {
-		return loginLogMapper.selectLoginLog(loginLog);
-	}
+	LoginLog selectLoginLog(LoginLog loginLog) throws Exception;
 
 	/**
 	 * 접속로그 목록을 조회한다.
-	 *
 	 * @param loginLog LoginLog
 	 * @return List
-	 * @throws Exception
+	 * @exception Exception
 	 */
-	public List<LoginLog> selectLoginLogInf(LoginLog loginLog) throws Exception {
-		return loginLogMapper.selectLoginLogInf(loginLog);
-	}
+	List<LoginLog> selectLoginLogInf(LoginLog loginLog) throws Exception;
 
 	/**
 	 * 접속로그 목록의 총 건수를 조회한다.
-	 *
 	 * @param loginLog LoginLog
 	 * @return int
-	 * @throws Exception
+	 * @exception Exception
 	 */
-	public int selectLoginLogInfCnt(LoginLog loginLog) throws Exception {
-		return loginLogMapper.selectLoginLogInfCnt(loginLog);
-	}
+	int selectLoginLogInfCnt(LoginLog loginLog) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,10 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0에 신규 반영된 @EgovMapper(MyBatis) 어노테이션 방식을 활용해
sym/log/clg 패키지의 접속로그 매퍼를 XML namespace 기반 호출에서 타입 안전한 인터페이스 호출로 전환한다.

## 변경 내용
- `LoginLogMapper` 인터페이스 신설 (`@EgovMapper("loginLogMapper")` 적용)
- `LoginLogDAO`: `EgovAbstractMapper` 상속 제거, `LoginLogMapper` DI 방식으로 전환
- `EgovLoginLog_SQL_*.xml` 6개 파일: namespace를 `LoginLogDAO` → `egovframework.let.sym.log.clg.service.impl.LoginLogMapper` 로 변경
- `context-mapper.xml`: `MapperConfigurer` 빈 추가 (`basePackage: egovframework.let`)
- SQL 구문 자체는 변경 없음

## 영향 범위
- 외부 동작 변경 없음
- 컴파일 타임 타입 안전성 향상 (`List<?>` → `List<LoginLog>`)

## 체크리스트
- [x] 단일 모듈(sym/log/clg)만 다룸
- [x] 의존성 추가 없음
- [x] 기존 동작에 영향 없음
- [x] mvn compile 통과 확인
- [x] SQL 변경 없음
