### PR TITLE
[test][enterprise] EgovBBSLoneMasterServiceImpl 단위 테스트 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSLoneMasterServiceImplTestInsertMasterTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/service/impl/EgovBBSLoneMasterServiceImplTestInsertMasterTest.java
@@ -1,0 +1,118 @@
+package egovframework.let.cop.bbs.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.ImportResource;
+import org.springframework.test.context.ContextConfiguration;
+
+import egovframework.com.cmm.LoginVO;
+import egovframework.com.cmm.util.EgovUserDetailsHelper;
+import egovframework.let.cop.bbs.service.BoardMaster;
+import egovframework.let.cop.bbs.service.EgovBBSLoneMasterService;
+import egovframework.let.cop.com.service.impl.BBSUseInfoManageDAO;
+import egovframework.test.EgovTestAbstractSpring;
+
+/**
+ * [게시판생성관리][EgovBBSLoneMasterServiceImpl.insertMaster] ServiceImpl 단위 테스트
+ *
+ * @author 이백행
+ * @since 2024-09-17
+ */
+
+@ContextConfiguration(classes = { EgovBBSLoneMasterServiceImplTestInsertMasterTest.class,
+		EgovTestAbstractSpring.class })
+
+@Configuration
+
+@ImportResource({ "classpath*:egovframework/spring/com/context-idgen.xml", })
+
+@ComponentScan(useDefaultFilters = false, basePackages = { "egovframework.let.cop.bbs.service.impl",
+		"egovframework.let.cop.com.service.impl" }, includeFilters = {
+				@Filter(type = FilterType.ASSIGNABLE_TYPE, classes = { EgovBBSLoneMasterServiceImpl.class,
+						BBSLoneMasterDAO.class, BBSUseInfoManageDAO.class, }) })
+
+class EgovBBSLoneMasterServiceImplTestInsertMasterTest extends EgovTestAbstractSpring {
+
+	private static final Logger log = LoggerFactory.getLogger(EgovBBSLoneMasterServiceImplTestInsertMasterTest.class);
+
+	/**
+	 * 게시판 속성관리를 위한 서비스 인터페이스 클래스
+	 */
+	@Autowired
+	private EgovBBSLoneMasterService egovBBSLoneMasterService;
+
+	/**
+	 * 신규 게시판 속성정보를 생성한다.
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	void test() throws Exception {
+		// given
+		final BoardMaster boardMaster = new BoardMaster();
+
+		// 게시판ID
+		final LocalDateTime now = LocalDateTime.now();
+		final String now2 = now.format(DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss"));
+
+		// 게시판유형코드
+		// SELECT A.* FROM LETTCCMMNDETAILCODE AS A WHERE A.CODE_ID = 'COM004';
+		boardMaster.setBbsTyCode("BBST01");
+
+		// SELECT A.* FROM LETTCCMMNDETAILCODE AS A WHERE A.CODE_ID = 'COM009';
+		boardMaster.setBbsAttrbCode("BBSA03");
+
+		// 게시판명
+		boardMaster.setBbsNm("test 이백행 게시판명 " + now2);
+
+		// 게시판소개
+		boardMaster.setBbsIntrcn("test 이백행 게시판소개 " + now2);
+
+		// 답장가능여부
+		boardMaster.setReplyPosblAt("N");
+
+		// 파일첨부가능여부
+		boardMaster.setFileAtchPosblAt("Y");
+
+		// 첨부가능파일숫자
+		boardMaster.setPosblAtchFileNumber(3);
+
+		// 첨부가능파일사이즈
+		boardMaster.setPosblAtchFileSize("0");
+
+		// 템플릿ID
+		boardMaster.setTmplatId("TMPLAT_BOARD_DEFAULT");
+
+		// 사용여부
+		boardMaster.setUseAt("Y");
+
+		final LoginVO loginVO = (LoginVO) EgovUserDetailsHelper.getAuthenticatedUser();
+		if (loginVO != null) {
+			// 최초등록자ID
+			boardMaster.setFrstRegisterId(loginVO.getUniqId());
+		}
+
+		// when
+		final String result = egovBBSLoneMasterService.insertMaster(boardMaster);
+
+		// then
+		if (log.isDebugEnabled()) {
+			log.debug("boardMaster={}", boardMaster);
+			log.debug("getBbsId={}, {}", boardMaster.getBbsId(), result);
+		}
+
+		assertNotNull(result, "신규 게시판 속성정보를 생성한다.");
+	}
+
+}


### PR DESCRIPTION
게시판 단위 속성관리 서비스(`EgovBBSLoneMasterServiceImpl`)의 `insertMaster` 메서드에 대한 Spring 통합 테스트를 추가합니다.

## 변경 사유

enterprise 템플릿의 30개 ServiceImpl 중 테스트가 3건뿐으로 커버리지가 낮습니다. 게시판 속성 생성(`insertMaster`)은 핵심 기능이나 테스트가 없어 추가하였습니다.

## 변경 내용

- `pom.xml`: `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 — Lombok 어노테이션 처리기를 명시적으로 등록하여 `@Slf4j` 등이 컴파일 단계에서 정상 처리되도록 수정 (기존 테스트 파일들이 `@Slf4j`를 사용하나 annotation processor 미등록으로 컴파일 불가 상태였음)
- `EgovBBSLoneMasterServiceImplTestInsertMasterTest.java`: `insertMaster` 호출 후 반환된 게시판ID가 null이 아님을 검증하는 Spring 통합 테스트 추가
  - `BBSLoneMasterDAO`, `BBSUseInfoManageDAO` 빈 포함
  - `@Transactional` 롤백으로 DB 부작용 없음
  - 기존 `EgovBBSAttributeManageServiceImplTest`와 동일한 패턴 사용

## 영향 범위

테스트 코드 및 빌드 설정만 변경. 운영 코드 변경 없음.

## 체크리스트

- [x] 단일 주제만 다룸 (게시판 단위 테스트)
- [x] 기존 동작에 영향 없음
- [x] mvn test-compile BUILD SUCCESS 확인
