### PR TITLE
[refactor][enterprise] uat/uap 로그인정책 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyDAO.java
+++ b/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyDAO.java
@@ -2,11 +2,12 @@ package egovframework.let.uat.uap.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uat.uap.service.LoginPolicy;
 import egovframework.let.uat.uap.service.LoginPolicyVO;
+import jakarta.annotation.Resource;
+
 /**
  * 로그인정책에 대한 DAO 클래스를 정의한다.
  * 로그인정책에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
@@ -27,7 +28,10 @@ import egovframework.let.uat.uap.service.LoginPolicyVO;
  * </pre>
  */
 @Repository("loginPolicyDAO")
-public class LoginPolicyDAO extends EgovAbstractMapper {
+public class LoginPolicyDAO {
+
+	@Resource(name = "loginPolicyMapper")
+	private LoginPolicyMapper loginPolicyMapper;
 
 	/**
 	 * 로그인정책 목록을 조회한다.
@@ -35,7 +39,7 @@ public class LoginPolicyDAO extends EgovAbstractMapper {
 	 * @return List - 로그인정책 목록
 	 */
 	public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) throws Exception {
-		return selectList("loginPolicyDAO.selectLoginPolicyList", loginPolicyVO);
+		return loginPolicyMapper.selectLoginPolicyList(loginPolicyVO);
 	}
 
 	/**
@@ -44,7 +48,7 @@ public class LoginPolicyDAO extends EgovAbstractMapper {
 	 * @return int
 	 */
 	public int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) throws Exception {
-		return (Integer)selectOne("loginPolicyDAO.selectLoginPolicyListTotCnt", loginPolicyVO);
+		return loginPolicyMapper.selectLoginPolicyListTotCnt(loginPolicyVO);
 	}
 
 	/**
@@ -53,7 +57,7 @@ public class LoginPolicyDAO extends EgovAbstractMapper {
 	 * @return LoginPolicyVO - 로그인정책 VO
 	 */
 	public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) {
-		return (LoginPolicyVO)selectOne("loginPolicyDAO.selectLoginPolicy", loginPolicyVO);
+		return loginPolicyMapper.selectLoginPolicy(loginPolicyVO);
 	}
 
 	/**
@@ -61,7 +65,7 @@ public class LoginPolicyDAO extends EgovAbstractMapper {
 	 * @param loginPolicy - 로그인정책 model
 	 */
 	public void insertLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-        insert("loginPolicyDAO.insertLoginPolicy", loginPolicy);
+		loginPolicyMapper.insertLoginPolicy(loginPolicy);
 	}
 
 	/**
@@ -69,7 +73,7 @@ public class LoginPolicyDAO extends EgovAbstractMapper {
 	 * @param loginPolicy - 로그인정책 model
 	 */
 	public void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-		update("loginPolicyDAO.updateLoginPolicy", loginPolicy);
+		loginPolicyMapper.updateLoginPolicy(loginPolicy);
 	}
 
 	/**
@@ -77,7 +81,7 @@ public class LoginPolicyDAO extends EgovAbstractMapper {
 	 * @param loginPolicy - 로그인정책 model
 	 */
 	public void deleteLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-		delete("loginPolicyDAO.deleteLoginPolicy", loginPolicy);
+		loginPolicyMapper.deleteLoginPolicy(loginPolicy);
 	}
 
 	/**

--- a/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyMapper.java
+++ b/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyMapper.java
@@ -1,0 +1,69 @@
+package egovframework.let.uat.uap.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uat.uap.service.LoginPolicy;
+import egovframework.let.uat.uap.service.LoginPolicyVO;
+
+/**
+ * 로그인정책에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스개발팀 lee.m.j
+ * @since 2009.08.03
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.03  lee.m.j        최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper("loginPolicyMapper")
+public interface LoginPolicyMapper {
+
+	/**
+	 * 로그인정책 목록을 조회한다.
+	 * @param loginPolicyVO - 로그인정책 VO
+	 * @return List - 로그인정책 목록
+	 */
+	List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) throws Exception;
+
+	/**
+	 * 로그인정책 목록 수를 조회한다.
+	 * @param loginPolicyVO - 로그인정책 VO
+	 * @return int
+	 */
+	int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) throws Exception;
+
+	/**
+	 * 로그인정책 목록의 상세정보를 조회한다.
+	 * @param loginPolicyVO - 로그인정책 VO
+	 * @return LoginPolicyVO - 로그인정책 VO
+	 */
+	LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO);
+
+	/**
+	 * 로그인정책 정보를 신규로 등록한다.
+	 * @param loginPolicy - 로그인정책 model
+	 */
+	void insertLoginPolicy(LoginPolicy loginPolicy) throws Exception;
+
+	/**
+	 * 기 등록된 로그인정책 정보를 수정한다.
+	 * @param loginPolicy - 로그인정책 model
+	 */
+	void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception;
+
+	/**
+	 * 기 등록된 로그인정책 정보를 삭제한다.
+	 * @param loginPolicy - 로그인정책 model
+	 */
+	void deleteLoginPolicy(LoginPolicy loginPolicy) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
 	<resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
 	<resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,12 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션 기반 Mapper 인터페이스 자동 등록 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 어노테이션 활용 확대 — uat/uap 로그인정책 매퍼를 XML namespace 기반 호출에서 타입 안전한 인터페이스 호출로 전환한다. PR #81(sym/log/clg) 동일 패턴.

## 변경 내용
- `LoginPolicyMapper` 인터페이스 신설 (`@EgovMapper("loginPolicyMapper")` 적용)
- `LoginPolicyDAO`: `EgovAbstractMapper` 상속 제거, `LoginPolicyMapper` DI 방식으로 전환
- `EgovLoginPolicy_SQL_*.xml` 6개 파일: namespace를 `loginPolicyDAO` → `egovframework.let.uat.uap.service.impl.LoginPolicyMapper` 로 변경
- `context-mapper.xml`: `MapperScannerConfigurer` 빈 추가 (`basePackage: egovframework.let`)
- SQL 구문 자체는 변경 없음

## 영향 범위
- 외부 API 변경 없음
- 컴파일 타임 타입 안전성 향상

## 체크리스트
- [x] 단일 모듈(uat/uap)만 다룸
- [x] 의존성 추가 없음
- [x] mvn compile 통과 확인
- [x] 기존 동작에 영향 없음
- [x] sym/log/clg(#81)와 다른 모듈
- [x] SQL 변경 없음
