### PR TITLE
[refactor][enterprise] sec/rgm AuthorGroupDAO @EgovMapper 인터페이스 매핑

### DIFF
--- a/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupMapper.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/impl/AuthorGroupMapper.java
@@ -2,14 +2,13 @@ package egovframework.let.sec.rgm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sec.rgm.service.AuthorGroup;
 import egovframework.let.sec.rgm.service.AuthorGroupVO;
-import jakarta.annotation.Resource;
 
 /**
- * 권한그룹에 대한 DAO 클래스를 정의한다.
+ * 권한그룹에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -25,12 +24,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("authorGroupDAO")
-public class AuthorGroupDAO {
-
-	@Resource(name = "authorGroupMapper")
-	private AuthorGroupMapper authorGroupMapper;
+@EgovMapper("authorGroupMapper")
+public interface AuthorGroupMapper {
 
 	/**
 	 * 그룹별 할당된 권한 목록 조회
@@ -38,36 +33,28 @@ public class AuthorGroupDAO {
 	 * @return List<AuthorGroupVO>
 	 * @exception Exception
 	 */
-	public List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception {
-		return authorGroupMapper.selectAuthorGroupList(authorGroupVO);
-	}
+	List<AuthorGroupVO> selectAuthorGroupList(AuthorGroupVO authorGroupVO) throws Exception;
 
 	/**
 	 * 그룹에 권한정보를 할당하여 데이터베이스에 등록
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void insertAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.insertAuthorGroup(authorGroup);
-	}
+	void insertAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 화면에 조회된 그룹권한정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void updateAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.updateAuthorGroup(authorGroup);
-	}
+	void updateAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 그룹별 할당된 시스템 메뉴 접근권한을 삭제
 	 * @param authorGroup AuthorGroup
 	 * @exception Exception
 	 */
-	public void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception {
-		authorGroupMapper.deleteAuthorGroup(authorGroup);
-	}
+	void deleteAuthorGroup(AuthorGroup authorGroup) throws Exception;
 
 	/**
 	 * 그룹권한목록 총 갯수를 조회한다.
@@ -75,8 +62,6 @@ public class AuthorGroupDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception {
-		return authorGroupMapper.selectAuthorGroupListTotCnt(authorGroupVO);
-	}
+	int selectAuthorGroupListTotCnt(AuthorGroupVO authorGroupVO) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rgm/EgovAuthorGroup_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="authorGroupDAO">
+<mapper namespace="egovframework.let.sec.rgm.service.impl.AuthorGroupMapper">
 
 
     <resultMap id="authorGroup" type="egovframework.let.sec.rgm.service.AuthorGroupVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,10 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0 @EgovMapper 활용 확대. PR #81(sym/log/clg), #83(uat/uap) 동일 패턴.

## 변경 내용
- 신규 `AuthorGroupMapper` 인터페이스(@EgovMapper) 추가
- `AuthorGroupDAO`: `EgovAbstractMapper` 상속 제거, `@Resource` 주입 방식으로 전환
- 6개 RDBMS XML namespace를 인터페이스 FQN으로 변경 (altibase/cubrid/mysql/oracle/postgres/tibero)
- `context-mapper.xml`에 `MapperConfigurer` 빈 추가 (PR #81과 동일 — fast-forward 가능)
- SQL 무변경

## 영향 범위
- 외부 API 변경 없음
- 타입 안전성 향상

## 체크리스트
- [x] 단일 모듈(sec/rgm)
- [x] mvn compile 통과
- [x] sym/log/clg(#81), uat/uap(#83)와 다른 모듈
- [x] context-mapper.xml 변경은 PR #81과 동일
