### PR TITLE
[refactor][enterprise] sts/cst 접속통계 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sts/cst/service/impl/ConectStatsMapper.java
+++ b/src/main/java/egovframework/let/sts/cst/service/impl/ConectStatsMapper.java
@@ -2,13 +2,12 @@ package egovframework.let.sts.cst.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sts.com.StatsVO;
-import jakarta.annotation.Resource;
 
 /**
- * 접속 통계 검색 DAO 클래스
+ * 접속 통계 조회에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 박지욱
  * @since 2009.03.12
  * @version 1.0
@@ -26,21 +25,15 @@ import jakarta.annotation.Resource;
  *
  *  </pre>
  */
-@Repository("conectStatsDAO")
-public class ConectStatsDAO {
-
-	@Resource(name = "conectStatsMapper")
-	private ConectStatsMapper conectStatsMapper;
+@EgovMapper("conectStatsMapper")
+public interface ConectStatsMapper {
 
 	/**
 	 * 접속 통계를 조회한다
-	 *
 	 * @param vo StatsVO
 	 * @return List
 	 * @exception Exception
 	 */
-	public List<StatsVO> selectConectStats(StatsVO vo) throws Exception {
-		return conectStatsMapper.selectConectStats(vo);
-	}
+	List<StatsVO> selectConectStats(StatsVO vo) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.let.sts.cst.service.impl.ConectStatsMapper">
 
 	
 	<!-- 접속통계 조회 -->

--- a/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.let.sts.cst.service.impl.ConectStatsMapper">
 
 	
 	<!-- 접속통계 조회 -->

--- a/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.let.sts.cst.service.impl.ConectStatsMapper">
 
 	
 	<!-- 접속통계 조회 -->

--- a/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.let.sts.cst.service.impl.ConectStatsMapper">
 
 	
 	<!-- 접속통계 조회 -->

--- a/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.let.sts.cst.service.impl.ConectStatsMapper">
 
 	
 	<!-- 접속통계 조회 -->

--- a/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sts/cst/EgovConectStats_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ConectStatsDAO">
+<mapper namespace="egovframework.let.sts.cst.service.impl.ConectStatsMapper">
 
 	
 	<!-- 접속통계 조회 -->

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,10 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0에 신규 반영된 @EgovMapper(MyBatis) 어노테이션 방식을 활용해
sts/cst 패키지의 접속통계 매퍼를 XML namespace 기반 호출에서 타입 안전한 인터페이스 호출로 전환한다.
PR #81(sym/log/clg), #83(uat/uap), #84(sec/rgm)과 동일 패턴.

## 변경 내용
- `ConectStatsMapper` 인터페이스 신설 (`@EgovMapper("conectStatsMapper")` 적용)
- `ConectStatsDAO`: `EgovAbstractMapper` 상속 제거, `ConectStatsMapper` DI 방식으로 전환
- `EgovConectStats_SQL_*.xml` 6개 파일: namespace를 `ConectStatsDAO` → `egovframework.let.sts.cst.service.impl.ConectStatsMapper` 로 변경
- `context-mapper.xml`: `MapperConfigurer` 빈 추가 (`basePackage: egovframework.let`)
- SQL 구문 자체는 변경 없음

## 영향 범위
- 외부 API 변경 없음
- 컴파일 타임 타입 안전성 향상 (`List<?>` → `List<StatsVO>`)

## 체크리스트
- [x] 단일 모듈(sts/cst)만 다룸
- [x] 의존성 추가 없음
- [x] SQL 변경 없음
- [x] mvn compile 통과 확인
- [x] PR #81, #83, #84와 다른 모듈