### PR TITLE
[refactor][enterprise] sec/gmt 그룹관리 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageMapper.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/impl/GroupManageMapper.java
@@ -2,14 +2,13 @@ package egovframework.let.sec.gmt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sec.gmt.service.GroupManage;
 import egovframework.let.sec.gmt.service.GroupManageVO;
-import jakarta.annotation.Resource;
 
 /**
- * 그룹관리에 대한 DAO 클래스를 정의한다.
+ * 그룹관리에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -26,12 +25,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("groupManageDAO")
-public class GroupManageDAO {
-
-	@Resource(name = "groupManageMapper")
-	private GroupManageMapper groupManageMapper;
+@EgovMapper("groupManageMapper")
+public interface GroupManageMapper {
 
 	/**
 	 * 검색조건에 따른 그룹정보를 조회
@@ -39,9 +34,7 @@ public class GroupManageDAO {
 	 * @return GroupManageVO
 	 * @exception Exception
 	 */
-	public GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroup(groupManageVO);
-	}
+	GroupManageVO selectGroup(GroupManageVO groupManageVO) throws Exception;
 
 	/**
 	 * 시스템사용 목적별 그룹 목록 조회
@@ -49,36 +42,28 @@ public class GroupManageDAO {
 	 * @return List&lt;GroupManageVO&gt;
 	 * @exception Exception
 	 */
-	public List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroupList(groupManageVO);
-	}
+	List<GroupManageVO> selectGroupList(GroupManageVO groupManageVO) throws Exception;
 
 	/**
 	 * 그룹 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void insertGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.insertGroup(groupManage);
-	}
+	void insertGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 화면에 조회된 그룹의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void updateGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.updateGroup(groupManage);
-	}
+	void updateGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 불필요한 그룹정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param groupManage GroupManage
 	 * @exception Exception
 	 */
-	public void deleteGroup(GroupManage groupManage) throws Exception {
-		groupManageMapper.deleteGroup(groupManage);
-	}
+	void deleteGroup(GroupManage groupManage) throws Exception;
 
 	/**
 	 * 그룹 목록 총 갯수를 조회한다.
@@ -86,8 +71,6 @@ public class GroupManageDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception {
-		return groupManageMapper.selectGroupListTotCnt(groupManageVO);
-	}
+	int selectGroupListTotCnt(GroupManageVO groupManageVO) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
 	<resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
 	<resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/gmt/EgovGroupManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="groupManageDAO">
+<mapper namespace="egovframework.let.sec.gmt.service.impl.GroupManageMapper">
 
 
     <resultMap id="group" type="egovframework.let.sec.gmt.service.GroupManageVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,10 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
eGovFrame 5.0에서 권장하는 @EgovMapper 어노테이션 방식을 sec/gmt 그룹관리 모듈에 적용합니다.
PR #81(sym/log/clg), #83(uat/uap), #84(sec/rgm), #85(sts/cst)와 동일한 패턴입니다.

## 변경 내용
- GroupManageMapper 인터페이스 신설 (`@EgovMapper("groupManageMapper")` 적용)
- GroupManageDAO: EgovAbstractMapper 상속 제거, GroupManageMapper DI 방식으로 전환
- EgovGroupManage_SQL_*.xml 6개 파일: namespace를 `groupManageDAO`에서 FQN(`egovframework.let.sec.gmt.service.impl.GroupManageMapper`)으로 변경
- context-mapper.xml: MapperConfigurer 빈 추가 (basePackage: egovframework.let)
- SQL 구문 자체는 변경 없음

## 영향 범위
- 외부 API(서비스 인터페이스, 컨트롤러) 변경 없음
- GroupManageDAO의 public 메서드 시그니처 동일 유지

## 체크리스트
- [x] 단일 모듈(sec/gmt)만 다룸
- [x] mvn compile 통과
- [x] PR #81, #83, #84, #85와 다른 모듈
- [x] SQL 의미 변경 없음
- [x] 의존성 추가 없음 (MapperConfigurer는 기존 rte-psl 포함)