### PR TITLE
[refactor][enterprise] sec 모듈 모델/VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/sec/gmt/service/GroupManage.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/GroupManage.java
@@ -3,6 +3,8 @@ package egovframework.let.sec.gmt.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 그룹관리에 대한 model 클래스를 정의한다.
@@ -22,6 +24,8 @@ import egovframework.com.cmm.ComDefaultVO;
  * </pre>
  */
 
+@Getter
+@Setter
 public class GroupManage extends ComDefaultVO {
 	/**
 	 * serialVersionUID
@@ -51,74 +55,4 @@ public class GroupManage extends ComDefaultVO {
 	@Size(max=50)
 	private String groupDc;
 	
-	/**
-	 * groupManage attribute 를 리턴한다.
-	 * @return GroupManage
-	 */
-	public GroupManage getGroupManage() {
-		return groupManage;
-	}
-	/**
-	 * groupManage attribute 값을 설정한다.
-	 * @param groupManage GroupManage 
-	 */
-	public void setGroupManage(GroupManage groupManage) {
-		this.groupManage = groupManage;
-	}
-	/**
-	 * groupId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupId() {
-		return groupId;
-	}
-	/**
-	 * groupId attribute 값을 설정한다.
-	 * @param groupId String 
-	 */
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
-	/**
-	 * groupNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupNm() {
-		return groupNm;
-	}
-	/**
-	 * groupNm attribute 값을 설정한다.
-	 * @param groupNm String 
-	 */
-	public void setGroupNm(String groupNm) {
-		this.groupNm = groupNm;
-	}
-	/**
-	 * groupCreatDe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupCreatDe() {
-		return groupCreatDe;
-	}
-	/**
-	 * groupCreatDe attribute 값을 설정한다.
-	 * @param groupCreatDe String 
-	 */
-	public void setGroupCreatDe(String groupCreatDe) {
-		this.groupCreatDe = groupCreatDe;
-	}
-	/**
-	 * groupDc attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupDc() {
-		return groupDc;
-	}
-	/**
-	 * groupDc attribute 값을 설정한다.
-	 * @param groupDc String 
-	 */
-	public void setGroupDc(String groupDc) {
-		this.groupDc = groupDc;
-	}
 }

--- a/src/main/java/egovframework/let/sec/gmt/service/GroupManageVO.java
+++ b/src/main/java/egovframework/let/sec/gmt/service/GroupManageVO.java
@@ -2,7 +2,8 @@ package egovframework.let.sec.gmt.service;
 
 import java.util.List;
 
-
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 그룹관리에 대한 Vo 클래스를 정의한다.
@@ -13,15 +14,17 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class GroupManageVO extends GroupManage {
 
 	/**
@@ -30,43 +33,11 @@ public class GroupManageVO extends GroupManage {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 그룹 목록
-	 */	
-	List <GroupManageVO> groupManageList;
+	 */
+	List<GroupManageVO> groupManageList;
 	/**
 	 * 삭제대상 목록
-	 */		
-    String[] delYn;
-
-	/**
-	 * groupManageList attribute 를 리턴한다.
-	 * @return List<GroupManageVO>
 	 */
-	public List<GroupManageVO> getGroupManageList() {
-		return groupManageList;
-	}
-
-	/**
-	 * groupManageList attribute 값을 설정한다.
-	 * @param groupManageList List<GroupManageVO> 
-	 */
-	public void setGroupManageList(List<GroupManageVO> groupManageList) {
-		this.groupManageList = groupManageList;
-	}
-
-	/**
-	 * delYn attribute 를 리턴한다.
-	 * @return String[]
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-
-	/**
-	 * delYn attribute 값을 설정한다.
-	 * @param delYn String[] 
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
+	String[] delYn;
 
 }

--- a/src/main/java/egovframework/let/sec/ram/service/AuthorManage.java
+++ b/src/main/java/egovframework/let/sec/ram/service/AuthorManage.java
@@ -3,6 +3,8 @@ package egovframework.let.sec.ram.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 권한관리에 대한 model 클래스를 정의한다.
@@ -13,15 +15,17 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class AuthorManage extends ComDefaultVO {
 
 	/**
@@ -30,7 +34,7 @@ public class AuthorManage extends ComDefaultVO {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 권한관리
-	 */	
+	 */
 	private AuthorManage authorManage;
 	/**
 	 * 권한코드
@@ -52,80 +56,5 @@ public class AuthorManage extends ComDefaultVO {
 	@EgovNullCheck
 	@Size(max=50)
 	private String authorNm;
-	
-	/**
-	 * authorManage attribute 를 리턴한다.
-	 * @return AuthorManage
-	 */
-	public AuthorManage getAuthorManage() {
-		return authorManage;
-	}
-	/**
-	 * authorManage attribute 값을 설정한다.
-	 * @param authorManage AuthorManage 
-	 */
-	public void setAuthorManage(AuthorManage authorManage) {
-		this.authorManage = authorManage;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * authorCreatDe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCreatDe() {
-		return authorCreatDe;
-	}
-	/**
-	 * authorCreatDe attribute 값을 설정한다.
-	 * @param authorCreatDe String 
-	 */
-	public void setAuthorCreatDe(String authorCreatDe) {
-		this.authorCreatDe = authorCreatDe;
-	}
-	/**
-	 * authorDc attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorDc() {
-		return authorDc;
-	}
-	/**
-	 * authorDc attribute 값을 설정한다.
-	 * @param authorDc String 
-	 */
-	public void setAuthorDc(String authorDc) {
-		this.authorDc = authorDc;
-	}
-	/**
-	 * authorNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorNm() {
-		return authorNm;
-	}
-	/**
-	 * authorNm attribute 값을 설정한다.
-	 * @param authorNm String 
-	 */
-	public void setAuthorNm(String authorNm) {
-		this.authorNm = authorNm;
-	}
-	
-
-
-	
 
 }

--- a/src/main/java/egovframework/let/sec/ram/service/AuthorManageVO.java
+++ b/src/main/java/egovframework/let/sec/ram/service/AuthorManageVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,37 +14,21 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class AuthorManageVO extends AuthorManage {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorManageVO> authorManageList;
-
-	/**
-	 * authorManageList attribute 를 리턴한다.
-	 * @return List<AuthorManageVO>
-	 */
-	public List<AuthorManageVO> getAuthorManageList() {
-		return authorManageList;
-	}
-
-	/**
-	 * authorManageList attribute 값을 설정한다.
-	 * @param authorManageList List<AuthorManageVO> 
-	 */
-	public void setAuthorManageList(List<AuthorManageVO> authorManageList) {
-		this.authorManageList = authorManageList;
-	}
-
-
+	List<AuthorManageVO> authorManageList;
 
 }

--- a/src/main/java/egovframework/let/sec/ram/service/AuthorRoleManage.java
+++ b/src/main/java/egovframework/let/sec/ram/service/AuthorRoleManage.java
@@ -1,6 +1,8 @@
 package egovframework.let.sec.ram.service;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 권한별 롤 관리에 대한 model 클래스를 정의한다.
@@ -11,15 +13,17 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class AuthorRoleManage extends ComDefaultVO {
 
 	/**
@@ -28,7 +32,7 @@ public class AuthorRoleManage extends ComDefaultVO {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 권한 롤 관리
-	 */	
+	 */
 	private AuthorRoleManage authorRole;
 	/**
 	 * 권한코드
@@ -41,171 +45,30 @@ public class AuthorRoleManage extends ComDefaultVO {
 	/**
 	 * 롤명
 	 */
-	private String roleNm;	
+	private String roleNm;
 	/**
 	 * 롤 패턴
 	 */
-	private String rolePtn;	
+	private String rolePtn;
 	/**
 	 * 롤 설명
 	 */
-	private String roleDc;	
+	private String roleDc;
 	/**
 	 * 롤 타입
 	 */
-	private String roleTyp;	
+	private String roleTyp;
 	/**
 	 * 롤 순서정렬
 	 */
-	private String roleSort;	
+	private String roleSort;
 	/**
 	 * 롤 등록여부
 	 */
-	private String regYn;	
+	private String regYn;
 	/**
 	 * 등록일자
 	 */
 	private String creatDt;
-	/**
-	 * authorRole attribute 를 리턴한다.
-	 * @return AuthorRoleManage
-	 */
-	public AuthorRoleManage getAuthorRole() {
-		return authorRole;
-	}
-	/**
-	 * authorRole attribute 값을 설정한다.
-	 * @param authorRole AuthorRoleManage 
-	 */
-	public void setAuthorRole(AuthorRoleManage authorRole) {
-		this.authorRole = authorRole;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * roleCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleCode() {
-		return roleCode;
-	}
-	/**
-	 * roleCode attribute 값을 설정한다.
-	 * @param roleCode String 
-	 */
-	public void setRoleCode(String roleCode) {
-		this.roleCode = roleCode;
-	}
-	/**
-	 * roleNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleNm() {
-		return roleNm;
-	}
-	/**
-	 * roleNm attribute 값을 설정한다.
-	 * @param roleNm String 
-	 */
-	public void setRoleNm(String roleNm) {
-		this.roleNm = roleNm;
-	}
-	/**
-	 * rolePtn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRolePtn() {
-		return rolePtn;
-	}
-	/**
-	 * rolePtn attribute 값을 설정한다.
-	 * @param rolePtn String 
-	 */
-	public void setRolePtn(String rolePtn) {
-		this.rolePtn = rolePtn;
-	}
-	/**
-	 * roleDc attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleDc() {
-		return roleDc;
-	}
-	/**
-	 * roleDc attribute 값을 설정한다.
-	 * @param roleDc String 
-	 */
-	public void setRoleDc(String roleDc) {
-		this.roleDc = roleDc;
-	}
-	/**
-	 * roleTyp attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleTyp() {
-		return roleTyp;
-	}
-	/**
-	 * roleTyp attribute 값을 설정한다.
-	 * @param roleTyp String 
-	 */
-	public void setRoleTyp(String roleTyp) {
-		this.roleTyp = roleTyp;
-	}
-	/**
-	 * roleSort attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleSort() {
-		return roleSort;
-	}
-	/**
-	 * roleSort attribute 값을 설정한다.
-	 * @param roleSort String 
-	 */
-	public void setRoleSort(String roleSort) {
-		this.roleSort = roleSort;
-	}
-	/**
-	 * regYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRegYn() {
-		return regYn;
-	}
-	/**
-	 * regYn attribute 값을 설정한다.
-	 * @param regYn String 
-	 */
-	public void setRegYn(String regYn) {
-		this.regYn = regYn;
-	}
-	/**
-	 * creatDt attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getCreatDt() {
-		return creatDt;
-	}
-	/**
-	 * creatDt attribute 값을 설정한다.
-	 * @param creatDt String 
-	 */
-	public void setCreatDt(String creatDt) {
-		this.creatDt = creatDt;
-	}
-	
-	
+
 }

--- a/src/main/java/egovframework/let/sec/ram/service/AuthorRoleManageVO.java
+++ b/src/main/java/egovframework/let/sec/ram/service/AuthorRoleManageVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.ram.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한별 롤 관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,37 +14,21 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class AuthorRoleManageVO extends AuthorRoleManage {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorRoleManageVO> authorRoleList;
-
-	/**
-	 * authorRoleList attribute 를 리턴한다.
-	 * @return List<AuthorRoleManageVO>
-	 */
-	public List<AuthorRoleManageVO> getAuthorRoleList() {
-		return authorRoleList;
-	}
-
-	/**
-	 * authorRoleList attribute 값을 설정한다.
-	 * @param authorRoleList List<AuthorRoleManageVO> 
-	 */
-	public void setAuthorRoleList(List<AuthorRoleManageVO> authorRoleList) {
-		this.authorRoleList = authorRoleList;
-	}
-
-
+	List<AuthorRoleManageVO> authorRoleList;
 
 }

--- a/src/main/java/egovframework/let/sec/rgm/service/AuthorGroup.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/AuthorGroup.java
@@ -1,6 +1,8 @@
 package egovframework.let.sec.rgm.service;
 
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
@@ -12,15 +14,17 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class AuthorGroup extends ComDefaultVO {
 	/**
 	 * serialVersionUID
@@ -29,7 +33,7 @@ public class AuthorGroup extends ComDefaultVO {
 	/**
 	 * 권한그룹관리
 	 */
-	private AuthorGroup authorGroup;	
+	private AuthorGroup authorGroup;
 	/**
 	 * 설정대상 사용자 ID
 	 */
@@ -41,14 +45,14 @@ public class AuthorGroup extends ComDefaultVO {
 	/**
 	 * 설정대상 그룹 ID
 	 */
-	private String groupId;	
+	private String groupId;
 	/**
 	 * 설정대상 사용자 유형 코드
 	 */
 	private String mberTyCode;
 	/**
 	 * 설정대상 사용자 유형 명
-	 */	
+	 */
 	private String mberTyNm;
 	/**
 	 * 권한코드
@@ -62,135 +66,5 @@ public class AuthorGroup extends ComDefaultVO {
 	 * Uniq ID
 	 */
 	private String uniqId;
-	
-	/**
-	 * authorGroup attribute 를 리턴한다.
-	 * @return AuthorGroup
-	 */
-	public AuthorGroup getAuthorGroup() {
-		return authorGroup;
-	}
-	/**
-	 * authorGroup attribute 값을 설정한다.
-	 * @param authorGroup AuthorGroup 
-	 */
-	public void setAuthorGroup(AuthorGroup authorGroup) {
-		this.authorGroup = authorGroup;
-	}
-	/**
-	 * userId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserId() {
-		return userId;
-	}
-	/**
-	 * userId attribute 값을 설정한다.
-	 * @param userId String 
-	 */
-	public void setUserId(String userId) {
-		this.userId = userId;
-	}
-	/**
-	 * userNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUserNm() {
-		return userNm;
-	}
-	/**
-	 * userNm attribute 값을 설정한다.
-	 * @param userNm String 
-	 */
-	public void setUserNm(String userNm) {
-		this.userNm = userNm;
-	}
-	/**
-	 * groupId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getGroupId() {
-		return groupId;
-	}
-	/**
-	 * groupId attribute 값을 설정한다.
-	 * @param groupId String 
-	 */
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
-	/**
-	 * mberTyCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMberTyCode() {
-		return mberTyCode;
-	}
-	/**
-	 * mberTyCode attribute 값을 설정한다.
-	 * @param mberTyCode String 
-	 */
-	public void setMberTyCode(String mberTyCode) {
-		this.mberTyCode = mberTyCode;
-	}
-	/**
-	 * mberTyNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getMberTyNm() {
-		return mberTyNm;
-	}
-	/**
-	 * mberTyNm attribute 값을 설정한다.
-	 * @param mberTyNm String 
-	 */
-	public void setMberTyNm(String mberTyNm) {
-		this.mberTyNm = mberTyNm;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * regYn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRegYn() {
-		return regYn;
-	}
-	/**
-	 * regYn attribute 값을 설정한다.
-	 * @param regYn String 
-	 */
-	public void setRegYn(String regYn) {
-		this.regYn = regYn;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String 
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	
 
-	
-	
 }

--- a/src/main/java/egovframework/let/sec/rgm/service/AuthorGroupVO.java
+++ b/src/main/java/egovframework/let/sec/rgm/service/AuthorGroupVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.rgm.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 권한그룹에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,35 +14,21 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class AuthorGroupVO extends AuthorGroup {
 
 	private static final long serialVersionUID = 1L;
 
-	List <AuthorGroupVO> authorGroupList;
-
-	/**
-	 * authorGroupList attribute 를 리턴한다.
-	 * @return List<AuthorGroupVO>
-	 */
-	public List<AuthorGroupVO> getAuthorGroupList() {
-		return authorGroupList;
-	}
-	/**
-	 * authorGroupList attribute 값을 설정한다.
-	 * @param authorGroupList List<AuthorGroupVO> 
-	 */
-	public void setAuthorGroupList(List<AuthorGroupVO> authorGroupList) {
-		this.authorGroupList = authorGroupList;
-	}
-
+	List<AuthorGroupVO> authorGroupList;
 
 }

--- a/src/main/java/egovframework/let/sec/rmt/service/RoleManage.java
+++ b/src/main/java/egovframework/let/sec/rmt/service/RoleManage.java
@@ -3,6 +3,8 @@ package egovframework.let.sec.rmt.service;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import jakarta.validation.constraints.Size;
 import egovframework.com.cmm.ComDefaultVO;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * 롤관리에 대한 model 클래스를 정의한다.
@@ -13,15 +15,17 @@ import egovframework.com.cmm.ComDefaultVO;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class RoleManage extends ComDefaultVO {
 	/**
 	 * serialVersionUID
@@ -40,23 +44,23 @@ public class RoleManage extends ComDefaultVO {
 	 */
 	@EgovNullCheck
 	@Size(max=50)
-	private String roleNm;	
+	private String roleNm;
 	/**
 	 * 롤패턴
 	 */
 	@EgovNullCheck
 	@Size(max=50)
-	private String rolePtn;	
+	private String rolePtn;
 	/**
 	 * 롤 설명
 	 */
 	@Size(max=50)
-	private String roleDc;		
+	private String roleDc;
 	/**
 	 * 롤 타입
 	 */
 	@EgovNullCheck
-	private String roleTyp;		
+	private String roleTyp;
 	/**
 	 * 롤 Sort
 	 */
@@ -71,133 +75,5 @@ public class RoleManage extends ComDefaultVO {
 	 * 권한 코드
 	 */
 	private String authorCode;
-	
-	/**
-	 * roleManage attribute 를 리턴한다.
-	 * @return RoleManage
-	 */
-	public RoleManage getRoleManage() {
-		return roleManage;
-	}
-	/**
-	 * roleManage attribute 값을 설정한다.
-	 * @param roleManage RoleManage 
-	 */
-	public void setRoleManage(RoleManage roleManage) {
-		this.roleManage = roleManage;
-	}
-	/**
-	 * roleCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleCode() {
-		return roleCode;
-	}
-	/**
-	 * roleCode attribute 값을 설정한다.
-	 * @param roleCode String 
-	 */
-	public void setRoleCode(String roleCode) {
-		this.roleCode = roleCode;
-	}
-	/**
-	 * roleNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleNm() {
-		return roleNm;
-	}
-	/**
-	 * roleNm attribute 값을 설정한다.
-	 * @param roleNm String 
-	 */
-	public void setRoleNm(String roleNm) {
-		this.roleNm = roleNm;
-	}
-	/**
-	 * rolePtn attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRolePtn() {
-		return rolePtn;
-	}
-	/**
-	 * rolePtn attribute 값을 설정한다.
-	 * @param rolePtn String 
-	 */
-	public void setRolePtn(String rolePtn) {
-		this.rolePtn = rolePtn;
-	}
-	/**
-	 * roleDc attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleDc() {
-		return roleDc;
-	}
-	/**
-	 * roleDc attribute 값을 설정한다.
-	 * @param roleDc String 
-	 */
-	public void setRoleDc(String roleDc) {
-		this.roleDc = roleDc;
-	}
-	/**
-	 * roleTyp attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleTyp() {
-		return roleTyp;
-	}
-	/**
-	 * roleTyp attribute 값을 설정한다.
-	 * @param roleTyp String 
-	 */
-	public void setRoleTyp(String roleTyp) {
-		this.roleTyp = roleTyp;
-	}
-	/**
-	 * roleSort attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleSort() {
-		return roleSort;
-	}
-	/**
-	 * roleSort attribute 값을 설정한다.
-	 * @param roleSort String 
-	 */
-	public void setRoleSort(String roleSort) {
-		this.roleSort = roleSort;
-	}
-	/**
-	 * roleCreatDe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getRoleCreatDe() {
-		return roleCreatDe;
-	}
-	/**
-	 * roleCreatDe attribute 값을 설정한다.
-	 * @param roleCreatDe String 
-	 */
-	public void setRoleCreatDe(String roleCreatDe) {
-		this.roleCreatDe = roleCreatDe;
-	}
-	/**
-	 * authorCode attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String 
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	
 
 }

--- a/src/main/java/egovframework/let/sec/rmt/service/RoleManageVO.java
+++ b/src/main/java/egovframework/let/sec/rmt/service/RoleManageVO.java
@@ -2,6 +2,9 @@ package egovframework.let.sec.rmt.service;
 
 import java.util.List;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 롤관리에 대한 Vo 클래스를 정의한다.
  * @author 공통서비스 개발팀 이문준
@@ -11,15 +14,17 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이문준          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
 
+@Getter
+@Setter
 public class RoleManageVO extends RoleManage {
 	/**
 	 * serialVersionUID
@@ -27,41 +32,11 @@ public class RoleManageVO extends RoleManage {
 	private static final long serialVersionUID = 1L;
 	/**
 	 * 롤 목록
-	 */	
-	List <RoleManageVO> roleManageList;
+	 */
+	List<RoleManageVO> roleManageList;
 	/**
 	 * 삭제대상 목록
-	 */		
-    String[] delYn;
+	 */
+	String[] delYn;
 
-	/**
-	 * roleManageList attribute 를 리턴한다.
-	 * @return List<RoleManageVO>
-	 */
-	public List<RoleManageVO> getRoleManageList() {
-		return roleManageList;
-	}
-	/**
-	 * roleManageList attribute 값을 설정한다.
-	 * @param roleManageList List<RoleManageVO> 
-	 */
-	public void setRoleManageList(List<RoleManageVO> roleManageList) {
-		this.roleManageList = roleManageList;
-	}
-	/**
-	 * delYn attribute 를 리턴한다.
-	 * @return String[]
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-	/**
-	 * delYn attribute 값을 설정한다.
-	 * @param delYn String[] 
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
-
-	
 }


### PR DESCRIPTION
sec 모듈(gmt/ram/rgm/rmt) 모델 및 VO 클래스의 수동 getter/setter를 Lombok @Getter/@Setter 어노테이션으로 대체합니다.

**변경 대상 (11개 파일)**
- `pom.xml` — maven-compiler-plugin에 annotationProcessorPaths 추가
- `sec/gmt`: GroupManage, GroupManageVO
- `sec/ram`: AuthorManage, AuthorManageVO, AuthorRoleManage, AuthorRoleManageVO
- `sec/rgm`: AuthorGroup, AuthorGroupVO
- `sec/rmt`: RoleManage, RoleManageVO

**변경 내용**
- 각 클래스에 `@Getter`, `@Setter` 어노테이션 추가
- 수동으로 작성된 getter/setter 메서드 제거
- 기존 필드 및 validation 어노테이션(`@EgovNullCheck`, `@Size`) 유지

**테스트**
- `mvn compile` 빌드 통과 확인

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [ ] 테스트 통과 확인
