### PR TITLE
[refactor][enterprise] sec/rmt 롤관리 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sec/rmt/service/impl/RoleManageMapper.java
+++ b/src/main/java/egovframework/let/sec/rmt/service/impl/RoleManageMapper.java
@@ -2,14 +2,13 @@ package egovframework.let.sec.rmt.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sec.rmt.service.RoleManage;
 import egovframework.let.sec.rmt.service.RoleManageVO;
-import jakarta.annotation.Resource;
 
 /**
- * 롤관리에 대한 DAO 클래스를 정의한다.
+ * 롤관리에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스 개발팀 이문준
  * @since 2009.06.01
  * @version 1.0
@@ -26,12 +25,8 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-
-@Repository("roleManageDAO")
-public class RoleManageDAO {
-
-	@Resource(name = "roleManageMapper")
-	private RoleManageMapper roleManageMapper;
+@EgovMapper("roleManageMapper")
+public interface RoleManageMapper {
 
 	/**
 	 * 등록된 롤 정보 조회
@@ -39,9 +34,7 @@ public class RoleManageDAO {
 	 * @return RoleManageVO
 	 * @exception Exception
 	 */
-	public RoleManageVO selectRole(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRole(roleManageVO);
-	}
+	RoleManageVO selectRole(RoleManageVO roleManageVO) throws Exception;
 
 	/**
 	 * 등록된 롤 정보 목록 조회
@@ -49,36 +42,28 @@ public class RoleManageDAO {
 	 * @return List<RoleManageVO>
 	 * @exception Exception
 	 */
-	public List<RoleManageVO> selectRoleList(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRoleList(roleManageVO);
-	}
+	List<RoleManageVO> selectRoleList(RoleManageVO roleManageVO) throws Exception;
 
 	/**
 	 * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 등록
 	 * @param roleManage RoleManage
 	 * @exception Exception
 	 */
-	public void insertRole(RoleManage roleManage) throws Exception {
-		roleManageMapper.insertRole(roleManage);
-	}
+	void insertRole(RoleManage roleManage) throws Exception;
 
 	/**
 	 * 시스템 메뉴에 따른 접근권한, 데이터 입력, 수정, 삭제의 권한 롤을 수정
 	 * @param roleManage RoleManage
 	 * @exception Exception
 	 */
-	public void updateRole(RoleManage roleManage) throws Exception {
-		roleManageMapper.updateRole(roleManage);
-	}
+	void updateRole(RoleManage roleManage) throws Exception;
 
 	/**
 	 * 불필요한 롤정보를 화면에 조회하여 데이터베이스에서 삭제
 	 * @param roleManage RoleManage
 	 * @exception Exception
 	 */
-	public void deleteRole(RoleManage roleManage) throws Exception {
-		roleManageMapper.deleteRole(roleManage);
-	}
+	void deleteRole(RoleManage roleManage) throws Exception;
 
 	/**
 	 * 롤목록 총 갯수를 조회한다.
@@ -86,9 +71,7 @@ public class RoleManageDAO {
 	 * @return int
 	 * @exception Exception
 	 */
-	public int selectRoleListTotCnt(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRoleListTotCnt(roleManageVO);
-	}
+	int selectRoleListTotCnt(RoleManageVO roleManageVO) throws Exception;
 
 	/**
 	 * 등록된 모든 롤 정보 목록 조회
@@ -96,8 +79,6 @@ public class RoleManageDAO {
 	 * @return List<RoleManageVO>
 	 * @exception Exception
 	 */
-	public List<RoleManageVO> selectRoleAllList(RoleManageVO roleManageVO) throws Exception {
-		return roleManageMapper.selectRoleAllList(roleManageVO);
-	}
+	List<RoleManageVO> selectRoleAllList(RoleManageVO roleManageVO) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sec/rmt/EgovRoleManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="roleManageDAO">
+<mapper namespace="egovframework.let.sec.rmt.service.impl.RoleManageMapper">
 
 
     <resultMap id="role" type="egovframework.let.sec.rmt.service.RoleManageVO">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,10 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 어노테이션이 선언된 Mapper 인터페이스를 자동으로 스캔하여 빈으로 등록한다 -->
+	<bean class="org.egovframe.rte.psl.dataaccess.mapper.MapperConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
sec/rmt 롤관리 모듈의 DAO를 eGovFrame 5.0에서 도입된 `@EgovMapper` 어노테이션 방식으로 전환한다.

**변경 내용**

- `RoleManageMapper` 인터페이스 신설 — `@EgovMapper("roleManageMapper")` 적용
- `RoleManageDAO`: `EgovAbstractMapper` 상속 제거, `RoleManageMapper`를 `@Resource`로 주입하여 위임 방식으로 전환
- `EgovRoleManage_SQL_*.xml` 6개 파일: `namespace`를 `roleManageDAO`에서 `egovframework.let.sec.rmt.service.impl.RoleManageMapper`로 변경
- `context-mapper.xml`: `MapperConfigurer` 빈 추가 (`basePackage: egovframework.let`) — `@EgovMapper` 스캔 활성화
- SQL 구문 자체는 변경 없음

**영향 범위**

- `EgovRoleManageServiceImpl` → `RoleManageDAO` 호출 방식 동일, 외부 인터페이스 변경 없음

**확인 사항**

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (SQL 및 공개 메서드 시그니처 동일)
- [ ] `mvn compile` 통과 확인
