### PR TITLE
[refactor][enterprise] uss/umt 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/UserDefaultVO.java
@@ -2,6 +2,8 @@ package egovframework.let.uss.umt.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -13,16 +15,18 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class UserDefaultVO implements Serializable {
-	
+
 	/**
 	 * serialVersionUID
 	 */
@@ -30,22 +34,22 @@ public class UserDefaultVO implements Serializable {
 
 	/** 검색조건-회원상태     (0, A, D, P)*/
     private String sbscrbSttus = "0";
-	
+
 	/** 검색조건 */
     private String searchCondition = "";
-    
+
     /** 검색Keyword */
     private String searchKeyword = "";
-    
+
     /** 검색사용여부 */
     private String searchUseYn = "";
-    
+
     /** 현재페이지 */
     private int pageIndex = 1;
-    
+
     /** 페이지갯수 */
     private int pageUnit = 10;
-    
+
     /** 페이지사이즈 */
     private int pageSize = 10;
 
@@ -58,166 +62,6 @@ public class UserDefaultVO implements Serializable {
     /** recordCountPerPage */
     private int recordCountPerPage = 10;
 
-	/**
-	 * sbscrbSttus attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbSttus() {
-		return sbscrbSttus;
-	}
-
-	/**
-	 * sbscrbSttus attribute 값을 설정한다.
-	 * @param sbscrbSttus String
-	 */
-	public void setSbscrbSttus(String sbscrbSttus) {
-		this.sbscrbSttus = sbscrbSttus;
-	}
-
-	/**
-	 * searchCondition attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchCondition() {
-		return searchCondition;
-	}
-
-	/**
-	 * searchCondition attribute 값을 설정한다.
-	 * @param searchCondition String
-	 */
-	public void setSearchCondition(String searchCondition) {
-		this.searchCondition = searchCondition;
-	}
-
-	/**
-	 * searchKeyword attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchKeyword() {
-		return searchKeyword;
-	}
-
-	/**
-	 * searchKeyword attribute 값을 설정한다.
-	 * @param searchKeyword String
-	 */
-	public void setSearchKeyword(String searchKeyword) {
-		this.searchKeyword = searchKeyword;
-	}
-
-	/**
-	 * searchUseYn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSearchUseYn() {
-		return searchUseYn;
-	}
-
-	/**
-	 * searchUseYn attribute 값을 설정한다.
-	 * @param searchUseYn String
-	 */
-	public void setSearchUseYn(String searchUseYn) {
-		this.searchUseYn = searchUseYn;
-	}
-
-	/**
-	 * pageIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageIndex() {
-		return pageIndex;
-	}
-
-	/**
-	 * pageIndex attribute 값을 설정한다.
-	 * @param pageIndex int
-	 */
-	public void setPageIndex(int pageIndex) {
-		this.pageIndex = pageIndex;
-	}
-
-	/**
-	 * pageUnit attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageUnit() {
-		return pageUnit;
-	}
-
-	/**
-	 * pageUnit attribute 값을 설정한다.
-	 * @param pageUnit int
-	 */
-	public void setPageUnit(int pageUnit) {
-		this.pageUnit = pageUnit;
-	}
-
-	/**
-	 * pageSize attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getPageSize() {
-		return pageSize;
-	}
-
-	/**
-	 * pageSize attribute 값을 설정한다.
-	 * @param pageSize int
-	 */
-	public void setPageSize(int pageSize) {
-		this.pageSize = pageSize;
-	}
-
-	/**
-	 * firstIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getFirstIndex() {
-		return firstIndex;
-	}
-
-	/**
-	 * firstIndex attribute 값을 설정한다.
-	 * @param firstIndex int
-	 */
-	public void setFirstIndex(int firstIndex) {
-		this.firstIndex = firstIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getLastIndex() {
-		return lastIndex;
-	}
-
-	/**
-	 * lastIndex attribute 값을 설정한다.
-	 * @param lastIndex int
-	 */
-	public void setLastIndex(int lastIndex) {
-		this.lastIndex = lastIndex;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을  리턴한다.
-	 * @return int
-	 */
-	public int getRecordCountPerPage() {
-		return recordCountPerPage;
-	}
-
-	/**
-	 * recordCountPerPage attribute 값을 설정한다.
-	 * @param recordCountPerPage int
-	 */
-	public void setRecordCountPerPage(int recordCountPerPage) {
-		this.recordCountPerPage = recordCountPerPage;
-	}
-    
 	/**
      * toString 메소드를 대치한다.
      */

--- a/src/main/java/egovframework/let/uss/umt/service/UserManageVO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/UserManageVO.java
@@ -1,5 +1,7 @@
 package egovframework.let.uss.umt.service;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
 import org.egovframe.rte.ptl.reactive.validation.EgovEmailCheck;
 import jakarta.validation.constraints.Size;
@@ -13,15 +15,17 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.04.10  조재영          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-public class UserManageVO extends UserDefaultVO{
+@Getter
+@Setter
+public class UserManageVO extends UserDefaultVO {
 
 	/**
 	 * serialVersionUID
@@ -30,15 +34,15 @@ public class UserManageVO extends UserDefaultVO{
 
 	/** 이전비밀번호 - 비밀번호 변경시 사용*/
     private String oldPassword = "";
-    
-    /**
+
+	/**
 	 * 가입일
 	 */
 	private String sbscrbDe;
 	/**
 	 * 사용자고유아이디
 	 */
-	private String uniqId="";
+	private String uniqId = "";
 	/**
 	 * 사용자 유형
 	 */
@@ -46,7 +50,7 @@ public class UserManageVO extends UserDefaultVO{
 	/**
 	 * 지역번호
 	 */
-	@Size(max=4)
+	@Size(max = 4)
 	private String areaNo;
 	/**
 	 * 생일
@@ -69,13 +73,13 @@ public class UserManageVO extends UserDefaultVO{
 	 * 사용자 ID
 	 */
 	@EgovNullCheck
-	@Size(max=20)
+	@Size(max = 20)
 	private String emplyrId;
 	/**
 	 * 사용자 명
 	 */
 	@EgovNullCheck
-	@Size(max=50)
+	@Size(max = 50)
 	private String emplyrNm;
 	/**
 	 * 사용자 상태
@@ -84,7 +88,7 @@ public class UserManageVO extends UserDefaultVO{
 	/**
 	 * 팩스번호
 	 */
-	@Size(max=15)
+	@Size(max = 15)
 	private String fxnum;
 	/**
 	 * 그룹 ID
@@ -93,17 +97,17 @@ public class UserManageVO extends UserDefaultVO{
 	/**
 	 * 집 주소
 	 */
-	@Size(max=100)
+	@Size(max = 100)
 	private String homeadres;
 	/**
 	 * 집끝전화번호
 	 */
-	@Size(max=4)
+	@Size(max = 4)
 	private String homeendTelno;
 	/**
 	 * 집중간전화번호
 	 */
-	@Size(max=4)
+	@Size(max = 4)
 	private String homemiddleTelno;
 	/**
 	 * 주민등록번호
@@ -121,7 +125,7 @@ public class UserManageVO extends UserDefaultVO{
 	 * 핸드폰번호
 	 */
 	@EgovNullCheck
-	@Size(max=15)
+	@Size(max = 15)
 	private String moblphonNo;
 	/**
 	 * 직위명
@@ -130,7 +134,7 @@ public class UserManageVO extends UserDefaultVO{
 	/**
 	 * 사무실전화번호
 	 */
-	@Size(max=15)
+	@Size(max = 15)
 	private String offmTelno;
 	/**
 	 * 조직 ID
@@ -145,7 +149,7 @@ public class UserManageVO extends UserDefaultVO{
 	 * 비밀번호 정답
 	 */
 	@EgovNullCheck
-	@Size(max=100)
+	@Size(max = 100)
 	private String passwordCnsr;
 	/**
 	 * 비밀번호 힌트
@@ -166,459 +170,11 @@ public class UserManageVO extends UserDefaultVO{
 	private String sexdstnCode;
 	/**
 	 * 우편번호
-	 */	
+	 */
 	private String zip;
 	/**
 	 * DN 값
-	 */	
+	 */
 	private String subDn;
-	/**
-	 * oldPassword attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getOldPassword() {
-		return oldPassword;
-	}
-	/**
-	 * oldPassword attribute 값을 설정한다.
-	 * @param oldPassword String
-	 */
-	public void setOldPassword(String oldPassword) {
-		this.oldPassword = oldPassword;
-	}
-	/**
-	 * sbscrbDe attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbDe() {
-		return sbscrbDe;
-	}
-	/**
-	 * sbscrbDe attribute 값을 설정한다.
-	 * @param sbscrbDe String
-	 */
-	public void setSbscrbDe(String sbscrbDe) {
-		this.sbscrbDe = sbscrbDe;
-	}
-	/**
-	 * uniqId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
-	/**
-	 * userTy attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getUserTy() {
-		return userTy;
-	}
-	/**
-	 * userTy attribute 값을 설정한다.
-	 * @param userTy String
-	 */
-	public void setUserTy(String userTy) {
-		this.userTy = userTy;
-	}
-	/**
-	 * areaNo attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getAreaNo() {
-		return areaNo;
-	}
-	/**
-	 * areaNo attribute 값을 설정한다.
-	 * @param areaNo String
-	 */
-	public void setAreaNo(String areaNo) {
-		this.areaNo = areaNo;
-	}
-	/**
-	 * brth attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getBrth() {
-		return brth;
-	}
-	/**
-	 * brth attribute 값을 설정한다.
-	 * @param brth String
-	 */
-	public void setBrth(String brth) {
-		this.brth = brth;
-	}
-	/**
-	 * detailAdres attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getDetailAdres() {
-		return detailAdres;
-	}
-	/**
-	 * detailAdres attribute 값을 설정한다.
-	 * @param detailAdres String
-	 */
-	public void setDetailAdres(String detailAdres) {
-		this.detailAdres = detailAdres;
-	}
-	/**
-	 * emailAdres attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getEmailAdres() {
-		return emailAdres;
-	}
-	/**
-	 * emailAdres attribute 값을 설정한다.
-	 * @param emailAdres String
-	 */
-	public void setEmailAdres(String emailAdres) {
-		this.emailAdres = emailAdres;
-	}
-	/**
-	 * emplNo attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getEmplNo() {
-		return emplNo;
-	}
-	/**
-	 * emplNo attribute 값을 설정한다.
-	 * @param emplNo String
-	 */
-	public void setEmplNo(String emplNo) {
-		this.emplNo = emplNo;
-	}
-	/**
-	 * emplyrId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getEmplyrId() {
-		return emplyrId;
-	}
-	/**
-	 * emplyrId attribute 값을 설정한다.
-	 * @param emplyrId String
-	 */
-	public void setEmplyrId(String emplyrId) {
-		this.emplyrId = emplyrId;
-	}
-	/**
-	 * emplyrNm attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getEmplyrNm() {
-		return emplyrNm;
-	}
-	/**
-	 * emplyrNm attribute 값을 설정한다.
-	 * @param emplyrNm String
-	 */
-	public void setEmplyrNm(String emplyrNm) {
-		this.emplyrNm = emplyrNm;
-	}
-	/**
-	 * emplyrSttusCode attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getEmplyrSttusCode() {
-		return emplyrSttusCode;
-	}
-	/**
-	 * emplyrSttusCode attribute 값을 설정한다.
-	 * @param emplyrSttusCode String
-	 */
-	public void setEmplyrSttusCode(String emplyrSttusCode) {
-		this.emplyrSttusCode = emplyrSttusCode;
-	}
-	/**
-	 * fxnum attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getFxnum() {
-		return fxnum;
-	}
-	/**
-	 * fxnum attribute 값을 설정한다.
-	 * @param fxnum String
-	 */
-	public void setFxnum(String fxnum) {
-		this.fxnum = fxnum;
-	}
-	/**
-	 * groupId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getGroupId() {
-		return groupId;
-	}
-	/**
-	 * groupId attribute 값을 설정한다.
-	 * @param groupId String
-	 */
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
-	/**
-	 * homeadres attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getHomeadres() {
-		return homeadres;
-	}
-	/**
-	 * homeadres attribute 값을 설정한다.
-	 * @param homeadres String
-	 */
-	public void setHomeadres(String homeadres) {
-		this.homeadres = homeadres;
-	}
-	/**
-	 * homeendTelno attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getHomeendTelno() {
-		return homeendTelno;
-	}
-	/**
-	 * homeendTelno attribute 값을 설정한다.
-	 * @param homeendTelno String
-	 */
-	public void setHomeendTelno(String homeendTelno) {
-		this.homeendTelno = homeendTelno;
-	}
-	/**
-	 * homemiddleTelno attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getHomemiddleTelno() {
-		return homemiddleTelno;
-	}
-	/**
-	 * homemiddleTelno attribute 값을 설정한다.
-	 * @param homemiddleTelno String
-	 */
-	public void setHomemiddleTelno(String homemiddleTelno) {
-		this.homemiddleTelno = homemiddleTelno;
-	}
-	/**
-	 * ihidnum attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getIhidnum() {
-		return ihidnum;
-	}
-	/**
-	 * ihidnum attribute 값을 설정한다.
-	 * @param ihidnum String
-	 */
-	public void setIhidnum(String ihidnum) {
-		this.ihidnum = ihidnum;
-	}
-	/**
-	 * insttCode attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getInsttCode() {
-		return insttCode;
-	}
-	/**
-	 * insttCode attribute 값을 설정한다.
-	 * @param insttCode String
-	 */
-	public void setInsttCode(String insttCode) {
-		this.insttCode = insttCode;
-	}
-	/**
-	 * mberTy attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMberTy() {
-		return mberTy;
-	}
-	/**
-	 * mberTy attribute 값을 설정한다.
-	 * @param mberTy String
-	 */
-	public void setMberTy(String mberTy) {
-		this.mberTy = mberTy;
-	}
-	/**
-	 * moblphonNo attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getMoblphonNo() {
-		return moblphonNo;
-	}
-	/**
-	 * moblphonNo attribute 값을 설정한다.
-	 * @param moblphonNo String
-	 */
-	public void setMoblphonNo(String moblphonNo) {
-		this.moblphonNo = moblphonNo;
-	}
-	/**
-	 * ofcpsNm attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getOfcpsNm() {
-		return ofcpsNm;
-	}
-	/**
-	 * ofcpsNm attribute 값을 설정한다.
-	 * @param ofcpsNm String
-	 */
-	public void setOfcpsNm(String ofcpsNm) {
-		this.ofcpsNm = ofcpsNm;
-	}
-	/**
-	 * offmTelno attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getOffmTelno() {
-		return offmTelno;
-	}
-	/**
-	 * offmTelno attribute 값을 설정한다.
-	 * @param offmTelno String
-	 */
-	public void setOffmTelno(String offmTelno) {
-		this.offmTelno = offmTelno;
-	}
-	/**
-	 * orgnztId attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * password attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getPassword() {
-		return password;
-	}
-	/**
-	 * password attribute 값을 설정한다.
-	 * @param password String
-	 */
-	public void setPassword(String password) {
-		this.password = password;
-	}
-	/**
-	 * passwordCnsr attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getPasswordCnsr() {
-		return passwordCnsr;
-	}
-	/**
-	 * passwordCnsr attribute 값을 설정한다.
-	 * @param passwordCnsr String
-	 */
-	public void setPasswordCnsr(String passwordCnsr) {
-		this.passwordCnsr = passwordCnsr;
-	}
-	/**
-	 * passwordHint attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getPasswordHint() {
-		return passwordHint;
-	}
-	/**
-	 * passwordHint attribute 값을 설정한다.
-	 * @param passwordHint String
-	 */
-	public void setPasswordHint(String passwordHint) {
-		this.passwordHint = passwordHint;
-	}
-	/**
-	 * sbscrbDeBegin attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbDeBegin() {
-		return sbscrbDeBegin;
-	}
-	/**
-	 * sbscrbDeBegin attribute 값을 설정한다.
-	 * @param sbscrbDeBegin String
-	 */
-	public void setSbscrbDeBegin(String sbscrbDeBegin) {
-		this.sbscrbDeBegin = sbscrbDeBegin;
-	}
-	/**
-	 * sbscrbDeEnd attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSbscrbDeEnd() {
-		return sbscrbDeEnd;
-	}
-	/**
-	 * sbscrbDeEnd attribute 값을 설정한다.
-	 * @param sbscrbDeEnd String
-	 */
-	public void setSbscrbDeEnd(String sbscrbDeEnd) {
-		this.sbscrbDeEnd = sbscrbDeEnd;
-	}
-	/**
-	 * sexdstnCode attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSexdstnCode() {
-		return sexdstnCode;
-	}
-	/**
-	 * sexdstnCode attribute 값을 설정한다.
-	 * @param sexdstnCode String
-	 */
-	public void setSexdstnCode(String sexdstnCode) {
-		this.sexdstnCode = sexdstnCode;
-	}
-	/**
-	 * zip attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getZip() {
-		return zip;
-	}
-	/**
-	 * zip attribute 값을 설정한다.
-	 * @param zip String
-	 */
-	public void setZip(String zip) {
-		this.zip = zip;
-	}
-	/**
-	 * subDn attribute 값을  리턴한다.
-	 * @return String
-	 */
-	public String getSubDn() {
-		return subDn;
-	}
-	/**
-	 * subDn attribute 값을 설정한다.
-	 * @param subDn String
-	 */
-	public void setSubDn(String subDn) {
-		this.subDn = subDn;
-	}
-	
+
 }


### PR DESCRIPTION
uss/umt 모듈의 `UserDefaultVO`, `UserManageVO`에 반복적으로 작성된 getter/setter 메서드를 Lombok `@Getter`/`@Setter` 어노테이션으로 대체한다.

**변경 내용**
- `UserDefaultVO`: 10개 필드 getter/setter 메서드 제거, `@Getter`/`@Setter` 어노테이션 적용
- `UserManageVO`: 25개 필드 getter/setter 메서드 제거, `@Getter`/`@Setter` 어노테이션 적용
- `pom.xml`: `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 (Lombok annotation processor 활성화)

**영향 범위**
- 생성된 바이트코드는 기존과 동일하여 기존 동작에 영향 없음

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 빌드 통과 확인 (`mvn compile`)
