### PR TITLE
[refactor][enterprise] uss/ion, uat/uap 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/uat/uap/service/LoginPolicyVO.java
+++ b/src/main/java/egovframework/let/uat/uap/service/LoginPolicyVO.java
@@ -1,6 +1,10 @@
 package egovframework.let.uat.uap.service;
 
 import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 로그인정책에 대한 VO 클래스를 정의한다.
  * 로그인정책정보의 목록 항목을 관리한다.
@@ -11,14 +15,16 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.08.03  lee.m.j        최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class LoginPolicyVO extends LoginPolicy {
 
 	/**
@@ -32,32 +38,6 @@ public class LoginPolicyVO extends LoginPolicy {
 	/**
 	 * 삭제 여부
 	 */
-	String [] delYn;
-	
-	/**
-	 * @return the loginPolicyList
-	 */
-	public List<LoginPolicyVO> getLoginPolicyList() {
-		return loginPolicyList;
-	}
-	/**
-	 * @param loginPolicyList the loginPolicyList to set
-	 */
-	public void setLoginPolicyList(List<LoginPolicyVO> loginPolicyList) {
-		this.loginPolicyList = loginPolicyList;
-	}
-	/**
-	 * @return the delYn
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-	/**
-	 * @param delYn the delYn to set
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
-	
-	
+	String[] delYn;
+
 }

--- a/src/main/java/egovframework/let/uss/ion/uas/service/UserAbsnceVO.java
+++ b/src/main/java/egovframework/let/uss/ion/uas/service/UserAbsnceVO.java
@@ -1,6 +1,10 @@
 package egovframework.let.uss.ion.uas.service;
 
 import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 사용자부재에 대한 Vo 클래스를 정의한다.
  * 사용자부재의 목록 항목을 관리한다.
@@ -11,19 +15,21 @@ import java.util.List;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.08.03  lee.m.j        최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class UserAbsnceVO extends UserAbsnce {
 	/**
 	 * serialVersionUID
 	 */
-	private static final long serialVersionUID = 1L;	
+	private static final long serialVersionUID = 1L;
 	/**
 	 * 사용자부재 목록
 	 */
@@ -34,47 +40,7 @@ public class UserAbsnceVO extends UserAbsnce {
 	String[] delYn;
 	/**
 	 * 부재여부 조회조건
-	 */	
+	 */
 	String selAbsnceAt;
-	
-	/**
-	 * @return the userAbsnceList
-	 */
-	public List<UserAbsnceVO> getUserAbsnceList() {
-		return userAbsnceList;
-	}
-	/**
-	 * @param userAbsnceList the userAbsnceList to set
-	 */
-	public void setUserAbsnceList(List<UserAbsnceVO> userAbsnceList) {
-		this.userAbsnceList = userAbsnceList;
-	}
-	/**
-	 * @return the delYn
-	 */
-	public String[] getDelYn() {
-		return delYn;
-	}
-	/**
-	 * @param delYn the delYn to set
-	 */
-	public void setDelYn(String[] delYn) {
-		this.delYn = delYn;
-	}
-	/**
-	 * @return the selAbsnceAt
-	 */
-	public String getSelAbsnceAt() {
-		return selAbsnceAt;
-	}
-	/**
-	 * @param selAbsnceAt the selAbsnceAt to set
-	 */
-	public void setSelAbsnceAt(String selAbsnceAt) {
-		this.selAbsnceAt = selAbsnceAt;
-	}
-	
 
-	
-	
 }


### PR DESCRIPTION
uss/ion, uat/uap 모듈 VO의 반복적인 getter/setter 메서드를 Lombok `@Getter`/`@Setter` 어노테이션으로 대체한다.

**변경 내용**
- `UserAbsnceVO`: 3개 필드 getter/setter 메서드 제거, `@Getter`/`@Setter` 어노테이션 적용
- `LoginPolicyVO`: 2개 필드 getter/setter 메서드 제거, `@Getter`/`@Setter` 어노테이션 적용
- `pom.xml`: `maven-compiler-plugin`에 `annotationProcessorPaths` 추가 (Lombok annotation processor 활성화)

**영향 범위**
- 생성된 바이트코드는 기존과 동일하여 기존 동작에 영향 없음

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음
- [ ] 빌드 통과 확인 (`mvn compile`)
