### PR TITLE
[refactor][enterprise] main/utl 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/main/service/EgovMainContentsVO.java
+++ b/src/main/java/egovframework/let/main/service/EgovMainContentsVO.java
@@ -2,6 +2,9 @@ package egovframework.let.main.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 템플릿 메인화면 작업 List 항목 VO(Sample 소스)
  * @author 실행환경 개발팀 JJY
@@ -11,13 +14,15 @@ import java.io.Serializable;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2011.08.31  JJY            최초 생성
  *
  * </pre>
  */
+@Getter
+@Setter
 public class EgovMainContentsVO implements Serializable {
 
 	/**
@@ -32,56 +37,9 @@ public class EgovMainContentsVO implements Serializable {
 	 * To-Do List 항목 별 업무화면 URL
 	 */
 	private String workItemURL;
-
 	/**
-	 * getItemCount 항목 개수 getter
-	 * @return
+	 * 항목 개수
 	 */
-	public int getItemCount(){
-		return 0;
-	}
-
-	/**
-	 * getWorkItemName To-Do List 항목 명 getter
-	 * @return To-Do List 항목 명
-	 */
-	public String getWorkItemName(){
-		return workItemName;
-	}
-
-	/**
-	 * getWorkItemURL 업무화면 URL getter
-	 * @return 업무화면 URL
-	 */
-	public String getWorkItemURL(){
-		return workItemURL;
-	}
-
-	/**
-	 * setItemCount 항목 개수 setter
-	 * 
-	 * @param itemCount    itemCount
-	 */
-	public void setItemCount(int itemCount){
-
-	}
-
-	/**
-	 * setWorkItemName To-Do List 항목 명 Setter
-	 * 
-	 * @param workItemName    To-Do List 항목 명
-	 */
-	public void setWorkItemName(String workItemName){
-
-	}
-
-	/**
-	 * setWorkItemURL 업무화면 URL setter
-	 * 
-	 * @param workItemURL    업무화면 URL
-	 */
-	public void setWorkItemURL(String workItemURL){
-
-	}
+	private int itemCount;
 
 }

--- a/src/main/java/egovframework/let/utl/fcc/service/EgovFormBasedFileVo.java
+++ b/src/main/java/egovframework/let/utl/fcc/service/EgovFormBasedFileVo.java
@@ -2,11 +2,14 @@ package egovframework.let.utl.fcc.service;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Class Name  : EgovFormBasedFileVo.java
  * @Description : Form-based File Upload VO
  * @Modification Information
- * 
+ *
  *     수정일         수정자                   수정내용
  *     -------          --------        ---------------------------
  *   2009.08.26       한성곤                  최초 생성
@@ -14,10 +17,12 @@ import java.io.Serializable;
  * @author 공통컴포넌트 개발팀 한성곤
  * @since 2009.08.26
  * @version 1.0
- * @see 
- * 
+ * @see
+ *
  *  Copyright (C) 2008 by MOPAS  All right reserved.
  */
+@Getter
+@Setter
 @SuppressWarnings("serial")
 public class EgovFormBasedFileVo implements Serializable {
     /** 파일명 */
@@ -30,75 +35,4 @@ public class EgovFormBasedFileVo implements Serializable {
     private String physicalName = "";
     /** 파일 사이즈 */
     private long size = 0L;
-    
-    /**
-     * fileName attribute를 리턴한다.
-     * @return the fileName
-     */
-    public String getFileName() {
-        return fileName;
-    }
-    /**
-     * fileName attribute 값을 설정한다.
-     * @param fileName the fileName to set
-     */
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-    /**
-     * contentType attribute를 리턴한다.
-     * @return the contentType
-     */
-    public String getContentType() {
-        return contentType;
-    }
-    /**
-     * contentType attribute 값을 설정한다.
-     * @param contentType the contentType to set
-     */
-    public void setContentType(String contentType) {
-        this.contentType = contentType;
-    }
-    /**
-     * serverSubPath attribute를 리턴한다.
-     * @return the serverSubPath
-     */
-    public String getServerSubPath() {
-        return serverSubPath;
-    }
-    /**
-     * serverSubPath attribute 값을 설정한다.
-     * @param serverSubPath the serverSubPath to set
-     */
-    public void setServerSubPath(String serverSubPath) {
-        this.serverSubPath = serverSubPath;
-    }
-    /**
-     * physicalName attribute를 리턴한다.
-     * @return the physicalName
-     */
-    public String getPhysicalName() {
-        return physicalName;
-    }
-    /**
-     * physicalName attribute 값을 설정한다.
-     * @param physicalName the physicalName to set
-     */
-    public void setPhysicalName(String physicalName) {
-        this.physicalName = physicalName;
-    }
-    /**
-     * size attribute를 리턴한다.
-     * @return the size
-     */
-    public long getSize() {
-        return size;
-    }
-    /**
-     * size attribute 값을 설정한다.
-     * @param size the size to set
-     */
-    public void setSize(long size) {
-        this.size = size;
-    }
 }


### PR DESCRIPTION
main 모듈의 EgovMainContentsVO와 utl/fcc 모듈의 EgovFormBasedFileVo에서
반복적인 getter/setter 메서드를 Lombok @Getter/@Setter 어노테이션으로 대체했다.

변경 내용:
- EgovMainContentsVO: 빈 구현의 setter/getter 제거, itemCount 필드 추가, @Getter/@Setter 적용
- EgovFormBasedFileVo: 5개 필드의 getter/setter 10개 메서드 제거, @Getter/@Setter 적용
- pom.xml: maven-compiler-plugin에 annotationProcessorPaths(lombok) 추가

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (getter/setter 메서드 시그니처 동일)
- [ ] mvn compile 통과 확인
