### PR TITLE
[refactor][enterprise] sym/mnu 모듈 VO Lombok @Getter/@Setter 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -285,6 +285,12 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
 					<release>${java.version}</release>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</path>
+					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/egovframework/let/sym/mnu/mcm/service/MenuCreatVO.java
+++ b/src/main/java/egovframework/let/sym/mnu/mcm/service/MenuCreatVO.java
@@ -1,8 +1,11 @@
 package egovframework.let.sym.mnu.mcm.service;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
- 
-/** 
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
  * 메뉴생성 처리를 위한 VO 클래스르를 정의한다
  * @author 개발환경 개발팀 이용
  * @since 2009.06.01
@@ -11,141 +14,41 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이  용          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-public class MenuCreatVO{
-
+@Getter
+@Setter
+public class MenuCreatVO {
 
    /** 메뉴번호 */
-   private   int      menuNo;
+   private int menuNo;
    /** 맵생성ID */
-   private   String   mapCreatId;
+   private String mapCreatId;
    /** 권한코드 */
-   private   String   authorCode;
+   private String authorCode;
 
    /** 권한정보설정 */
    /** 권한명 */
-   private   String   authorNm;
+   private String authorNm;
    /** 권한설명 */
-   private   String   authorDc;
+   private String authorDc;
    /** 권한생성일자 */
-   private   String   authorCreatDe;
+   private String authorCreatDe;
 
    /** 기타VO변수 */
    /** 생성자ID **/
-   private   String   creatPersonId;
+   private String creatPersonId;
 
-   
-	/**
-	 * menuNo attribute를 리턴한다.
-	 * @return int
-	 */
-	public int getMenuNo() {
-		return menuNo;
-	}
-	/**
-	 * menuNo attribute 값을 설정한다.
-	 * @param menuNo int
-	 */
-	public void setMenuNo(int menuNo) {
-		this.menuNo = menuNo;
-	}
-	/**
-	 * mapCreatId attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getMapCreatId() {
-		return mapCreatId;
-	}
-	/**
-	 * mapCreatId attribute 값을 설정한다.
-	 * @param mapCreatId String
-	 */
-	public void setMapCreatId(String mapCreatId) {
-		this.mapCreatId = mapCreatId;
-	}
-	/**
-	 * authorCode attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
-	/**
-	 * authorNm attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorNm() {
-		return authorNm;
-	}
-	/**
-	 * authorNm attribute 값을 설정한다.
-	 * @param authorNm String
-	 */
-	public void setAuthorNm(String authorNm) {
-		this.authorNm = authorNm;
-	}
-	/**
-	 * authorDc attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorDc() {
-		return authorDc;
-	}
-	/**
-	 * authorDc attribute 값을 설정한다.
-	 * @param authorDc String
-	 */
-	public void setAuthorDc(String authorDc) {
-		this.authorDc = authorDc;
-	}
-	/**
-	 * authorCreatDe attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCreatDe() {
-		return authorCreatDe;
-	}
-	/**
-	 * authorCreatDe attribute 값을 설정한다.
-	 * @param authorCreatDe String
-	 */
-	public void setAuthorCreatDe(String authorCreatDe) {
-		this.authorCreatDe = authorCreatDe;
-	}
-	/**
-	 * creatPersonId attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getCreatPersonId() {
-		return creatPersonId;
-	}
-	/**
-	 * creatPersonId attribute 값을 설정한다.
-	 * @param creatPersonId String
-	 */
-	public void setCreatPersonId(String creatPersonId) {
-		this.creatPersonId = creatPersonId;
-	}
-
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
-
+   /**
+    * toString 메소드를 대치한다.
+    */
+   public String toString() {
+      return ToStringBuilder.reflectionToString(this);
+   }
 }

--- a/src/main/java/egovframework/let/sym/mnu/mpm/service/MenuManageVO.java
+++ b/src/main/java/egovframework/let/sym/mnu/mpm/service/MenuManageVO.java
@@ -2,10 +2,13 @@ package egovframework.let.sym.mnu.mpm.service;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.egovframe.rte.ptl.reactive.validation.EgovNullCheck;
+
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
 
-/** 
+/**
  * 메뉴목록관리 처리를 위한 VO 클래스르를 정의한다
  * @author 개발환경 개발팀 이용
  * @since 2009.06.01
@@ -14,361 +17,79 @@ import jakarta.validation.constraints.Size;
  *
  * <pre>
  * << 개정이력(Modification Information) >>
- *   
+ *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이  용          최초 생성
- *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성 
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
-public class MenuManageVO{
+@Getter
+@Setter
+public class MenuManageVO {
 
    /** 메뉴정보 */
    /** 메뉴번호 */
    @Min(1)
-   private   int      menuNo;
+   private int menuNo;
    /** 메뉴순서 */
    @Min(1)
-   private   int      menuOrdr;
+   private int menuOrdr;
    /** 메뉴명 */
    @EgovNullCheck
    @Size(max=30)
-   private   String   menuNm;
+   private String menuNm;
    /** 상위메뉴번호 */
    @Min(0)
-   private   int      upperMenuId;
+   private int upperMenuId;
    /** 메뉴설명 */
-   private   String   menuDc;
+   private String menuDc;
    /** 관련이미지경로 */
    @Size(max=30)
-   private   String   relateImagePath;
+   private String relateImagePath;
    /** 관련이미지명 */
    @Size(max=30)
-   private   String   relateImageNm;
+   private String relateImageNm;
    /** 프로그램파일명 */
    @EgovNullCheck
    @Size(max=60)
-   private   String   progrmFileNm;
+   private String progrmFileNm;
 
    /** 사이트맵 */
    /** 생성자ID **/
-   private   String   creatPersonId;
+   private String creatPersonId;
 
    /** 권한정보설정 */
    /** 권한코드 */
-   private   String   authorCode;
+   private String authorCode;
 
    /** 기타VO변수 */
-   private   String   tempValue;
-   private   int      tempInt; 
-   
+   private String tempValue;
+   private int tempInt;
 
    /** Login 메뉴관련 VO변수 */
    /** tmp_Id */
-   private   String   tmp_Id;
+   private String tmp_Id;
    /** tmp_Password */
-   private   String   tmp_Password;
+   private String tmp_Password;
    /** tmp_Name */
-   private   String   tmp_Name;
+   private String tmp_Name;
    /** tmp_UserSe */
-   private   String   tmp_UserSe;
+   private String tmp_UserSe;
    /** tmp_Email */
-   private   String   tmp_Email;
+   private String tmp_Email;
    /** tmp_OrgnztId */
-   private   String   tmp_OrgnztId;
+   private String tmp_OrgnztId;
    /** tmp_UniqId */
-   private   String   tmp_UniqId;
+   private String tmp_UniqId;
    /** tmp_Cmd */
-   private   String   tmp_Cmd;
-   
-	/**
-	 * menuNo attribute를 리턴한다.
-	 * @return int
-	 */
-	public int getMenuNo() {
-		return menuNo;
-	}
-	/**
-	 * menuNo attribute 값을 설정한다.
-	 * @param menuNo int
-	 */
-	public void setMenuNo(int menuNo) {
-		this.menuNo = menuNo;
-	}
-	/**
-	 * menuOrdr attribute를 리턴한다.
-	 * @return int
-	 */
-	public int getMenuOrdr() {
-		return menuOrdr;
-	}
-	/**
-	 * menuOrdr attribute 값을 설정한다.
-	 * @param menuOrdr int
-	 */
-	public void setMenuOrdr(int menuOrdr) {
-		this.menuOrdr = menuOrdr;
-	}
-	/**
-	 * menuNm attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getMenuNm() {
-		return menuNm;
-	}
-	/**
-	 * menuNm attribute 값을 설정한다.
-	 * @param menuNm String
-	 */
-	public void setMenuNm(String menuNm) {
-		this.menuNm = menuNm;
-	}
-	/**
-	 * upperMenuId attribute를 리턴한다.
-	 * @return int
-	 */
-	public int getUpperMenuId() {
-		return upperMenuId;
-	}
-	/**
-	 * upperMenuId attribute 값을 설정한다.
-	 * @param upperMenuId int
-	 */
-	public void setUpperMenuId(int upperMenuId) {
-		this.upperMenuId = upperMenuId;
-	}
-	/**
-	 * menuDc attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getMenuDc() {
-		return menuDc;
-	}
-	/**
-	 * menuDc attribute 값을 설정한다.
-	 * @param menuDc String
-	 */
-	public void setMenuDc(String menuDc) {
-		this.menuDc = menuDc;
-	}
-	/**
-	 * relateImagePath attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getRelateImagePath() {
-		return relateImagePath;
-	}
-	/**
-	 * relateImagePath attribute 값을 설정한다.
-	 * @param relateImagePath String
-	 */
-	public void setRelateImagePath(String relateImagePath) {
-		this.relateImagePath = relateImagePath;
-	}
-	/**
-	 * relateImageNm attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getRelateImageNm() {
-		return relateImageNm;
-	}
-	/**
-	 * relateImageNm attribute 값을 설정한다.
-	 * @param relateImageNm String
-	 */
-	public void setRelateImageNm(String relateImageNm) {
-		this.relateImageNm = relateImageNm;
-	}
-	/**
-	 * progrmFileNm attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getProgrmFileNm() {
-		return progrmFileNm;
-	}
-	/**
-	 * progrmFileNm attribute 값을 설정한다.
-	 * @param progrmFileNm String
-	 */
-	public void setProgrmFileNm(String progrmFileNm) {
-		this.progrmFileNm = progrmFileNm;
-	}
-	/**
-	 * creatPersonId attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getCreatPersonId() {
-		return creatPersonId;
-	}
-	/**
-	 * creatPersonId attribute 값을 설정한다.
-	 * @param creatPersonId String
-	 */
-	public void setCreatPersonId(String creatPersonId) {
-		this.creatPersonId = creatPersonId;
-	}
-	/**
-	 * authorCode attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getAuthorCode() {
-		return authorCode;
-	}
-	/**
-	 * authorCode attribute 값을 설정한다.
-	 * @param authorCode String
-	 */
-	public void setAuthorCode(String authorCode) {
-		this.authorCode = authorCode;
-	}
+   private String tmp_Cmd;
 
-	/**
-	 * tmp_Id attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_Id() {
-		return tmp_Id;
-	}
-	/**
-	 * tmp_Id attribute 값을 설정한다.
-	 * @param tmp_Id String
-	 */
-	public void setTmp_Id(String tmp_Id) {
-		this.tmp_Id = tmp_Id;
-	}
-	/**
-	 * tmp_Password attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_Password() {
-		return tmp_Password;
-	}
-	/**
-	 * tmp_Password attribute 값을 설정한다.
-	 * @param tmp_Password String
-	 */
-	public void setTmp_Password(String tmp_Password) {
-		this.tmp_Password = tmp_Password;
-	}
-	/**
-	 * tmp_Name attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_Name() {
-		return tmp_Name;
-	}
-	/**
-	 * tmp_Name attribute 값을 설정한다.
-	 * @param tmp_Name String
-	 */
-	public void setTmp_Name(String tmp_Name) {
-		this.tmp_Name = tmp_Name;
-	}
-	/**
-	 * tmp_UserSe attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_UserSe() {
-		return tmp_UserSe;
-	}
-	/**
-	 * tmp_UserSe attribute 값을 설정한다.
-	 * @param tmp_UserSe String
-	 */
-	public void setTmp_UserSe(String tmp_UserSe) {
-		this.tmp_UserSe = tmp_UserSe;
-	}
-	/**
-	 * tmp_Email attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_Email() {
-		return tmp_Email;
-	}
-	/**
-	 * tmp_Email attribute 값을 설정한다.
-	 * @param tmp_Email String
-	 */
-	public void setTmp_Email(String tmp_Email) {
-		this.tmp_Email = tmp_Email;
-	}
-	/**
-	 * tmp_OrgnztId attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_OrgnztId() {
-		return tmp_OrgnztId;
-	}
-	/**
-	 * tmp_OrgnztId attribute 값을 설정한다.
-	 * @param tmp_OrgnztId String
-	 */
-	public void setTmp_OrgnztId(String tmp_OrgnztId) {
-		this.tmp_OrgnztId = tmp_OrgnztId;
-	}
-	/**
-	 * tmp_UniqId attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_UniqId() {
-		return tmp_UniqId;
-	}
-	/**
-	 * tmp_UniqId attribute 값을 설정한다.
-	 * @param tmp_UniqId String
-	 */
-	public void setTmp_UniqId(String tmp_UniqId) {
-		this.tmp_UniqId = tmp_UniqId;
-	}
-	/**
-	 * tmp_Cmd attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTmp_Cmd() {
-		return tmp_Cmd;
-	}
-	/**
-	 * tmp_Cmd attribute 값을 설정한다.
-	 * @param tmp_Cmd String
-	 */
-	public void setTmp_Cmd(String tmp_Cmd) {
-		this.tmp_Cmd = tmp_Cmd;
-	}
-	   
-	  /**
-	 * tempValue attribute를 리턴한다.
-	 * @return String
-	 */
-	public String getTempValue() {
-		return tempValue;
-	}
-	/**
-	 * tempValue attribute 값을 설정한다.
-	 * @param tempValue String
-	 */
-	public void setTempValue(String tempValue) {
-		this.tempValue = tempValue;
-	}
-	/**
-	 * tempInt attribute를 리턴한다.
-	 * @return int
-	 */
-	public int getTempInt() {
-		return tempInt;
-	}
-	/**
-	 * tempInt attribute 값을 설정한다.
-	 * @param tempInt int
-	 */
-	public void setTempInt(int tempInt) {
-		this.tempInt = tempInt;
-	}
-	/**
-     * toString 메소드를 대치한다.
-     */
-    public String toString() {
-    	return ToStringBuilder.reflectionToString(this);
-    }
+   /**
+    * toString 메소드를 대치한다.
+    */
+   public String toString() {
+      return ToStringBuilder.reflectionToString(this);
+   }
 }


### PR DESCRIPTION
sym/mnu 패키지(메뉴관리, 메뉴생성) VO 클래스의 수동 작성된 getter/setter 메서드를 Lombok `@Getter`/`@Setter` 어노테이션으로 대체한다.

변경 내용:
- `MenuManageVO`: 16개 필드의 getter/setter 제거, `@Getter`/`@Setter` 적용
- `MenuCreatVO`: 7개 필드의 getter/setter 제거, `@Getter`/`@Setter` 적용
- `pom.xml`: maven-compiler-plugin에 `annotationProcessorPaths` 추가 (Lombok 어노테이션 처리 명시)

기존 동작에 영향 없음 — Lombok이 컴파일 타임에 동일한 getter/setter를 생성한다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 빌드(`mvn compile`) 통과 확인
