### PR TITLE
[refactor][enterprise] sym/log/lgm 시스템 로그 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sym/log/lgm/service/impl/SysLogMapper.java
+++ b/src/main/java/egovframework/let/sym/log/lgm/service/impl/SysLogMapper.java
@@ -2,16 +2,15 @@ package egovframework.let.sym.log.lgm.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sym.log.lgm.service.SysLog;
-import jakarta.annotation.Resource;
 
 /**
- * 로그관리(시스템)를 위한 데이터 접근 클래스
+ * 시스템 로그 관리에 대한 Mapper 인터페이스를 정의한다.
  * @author 공통서비스개발팀 이삼섭
  * @since 2009.03.11
- * @version 1.0
+ * @version 2.0
  * @see
  *
  * <pre>
@@ -26,63 +25,50 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("SysLogDAO")
-public class SysLogDAO {
-
-	@Resource(name = "sysLogMapper")
-	private SysLogMapper sysLogMapper;
+@EgovMapper("sysLogMapper")
+public interface SysLogMapper {
 
 	/**
 	 * 시스템 로그정보를 생성한다.
-	 *
 	 * @param sysLog SysLog
 	 * @throws Exception
 	 */
-	public void logInsertSysLog(SysLog sysLog) throws Exception {
-		sysLogMapper.logInsertSysLog(sysLog);
-	}
+	void logInsertSysLog(SysLog sysLog) throws Exception;
 
 	/**
 	 * 시스템 로그정보를 요약한다.
-	 *
 	 * @throws Exception
 	 */
-	public void logInsertSysLogSummary() throws Exception {
-		sysLogMapper.logInsertSysLogSummary();
-		sysLogMapper.logDeleteSysLogSummary();
-	}
+	void logInsertSysLogSummary() throws Exception;
+
+	/**
+	 * 시스템 로그 6개월전 로그를 삭제한다.
+	 * @throws Exception
+	 */
+	void logDeleteSysLogSummary() throws Exception;
 
 	/**
 	 * 시스템 로그정보를 조회한다.
-	 *
 	 * @param sysLog SysLog
 	 * @return SysLog
 	 * @throws Exception
 	 */
-	public SysLog selectSysLog(SysLog sysLog) throws Exception {
-		return sysLogMapper.selectSysLog(sysLog);
-	}
+	SysLog selectSysLog(SysLog sysLog) throws Exception;
 
 	/**
 	 * 시스템 로그정보 목록을 조회한다.
-	 *
 	 * @param sysLog SysLog
 	 * @return List
 	 * @throws Exception
 	 */
-	public List<SysLog> selectSysLogInf(SysLog sysLog) throws Exception {
-		return sysLogMapper.selectSysLogInf(sysLog);
-	}
+	List<SysLog> selectSysLogInf(SysLog sysLog) throws Exception;
 
 	/**
 	 * 시스템 로그정보 목록의 총 건수를 조회한다.
-	 *
 	 * @param sysLog SysLog
 	 * @return int
 	 * @throws Exception
 	 */
-	public int selectSysLogInfCnt(SysLog sysLog) throws Exception {
-		return sysLogMapper.selectSysLogInfCnt(sysLog);
-	}
+	int selectSysLogInfCnt(SysLog sysLog) throws Exception;
 
 }

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
     <!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
     <!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
     <!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 VO -->
 


### PR DESCRIPTION
sym/log/lgm 패키지의 SysLogDAO가 EgovAbstractMapper를 상속하는 전통적인 방식으로 구현되어 있어 eGovFrame 5.0에서 도입된 @EgovMapper 인터페이스 방식으로 전환합니다.

변경 내용:
- SysLogMapper 인터페이스 신설 (@EgovMapper 어노테이션 적용)
- SysLogDAO에서 EgovAbstractMapper 상속 제거, SysLogMapper DI로 대체
- 반환 타입을 List<?>에서 List<SysLog>로 타입 안전하게 개선
- 6개 DB 방언 XML 파일의 namespace를 인터페이스 FQN으로 변경 (SQL 변경 없음)

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (SQL 변경 없이 매퍼 구조만 전환)
- [ ] 테스트 통과 확인 (mvn compile 성공)