### PR TITLE
[refactor][enterprise] cmm/SessionVO Lombok @Getter/@Setter 적용

### DIFF
--- a/src/main/java/egovframework/com/cmm/SessionVO.java
+++ b/src/main/java/egovframework/com/cmm/SessionVO.java
@@ -2,6 +2,9 @@ package egovframework.com.cmm;
 
 import java.io.Serializable;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * 세션 VO 클래스
  * @author 공통서비스 개발팀 박지욱
@@ -18,6 +21,8 @@ import java.io.Serializable;
  *
  *  </pre>
  */
+@Getter
+@Setter
 public class SessionVO implements Serializable {
 
 	private static final long serialVersionUID = -2848741427493626376L;
@@ -33,88 +38,4 @@ public class SessionVO implements Serializable {
 	private String orgnztId;
 	/** 고유아이디 */
 	private String uniqId;
-	/**
-	 * sUserId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserId() {
-		return sUserId;
-	}
-	/**
-	 * sUserId attribute 값을 설정한다.
-	 * @param sUserId String
-	 */
-	public void setSUserId(String userId) {
-		sUserId = userId;
-	}
-	/**
-	 * sUserNm attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserNm() {
-		return sUserNm;
-	}
-	/**
-	 * sUserNm attribute 값을 설정한다.
-	 * @param sUserNm String
-	 */
-	public void setSUserNm(String userNm) {
-		sUserNm = userNm;
-	}
-	/**
-	 * sEmail attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSEmail() {
-		return sEmail;
-	}
-	/**
-	 * sEmail attribute 값을 설정한다.
-	 * @param sEmail String
-	 */
-	public void setSEmail(String email) {
-		sEmail = email;
-	}
-	/**
-	 * sUserSe attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getSUserSe() {
-		return sUserSe;
-	}
-	/**
-	 * sUserSe attribute 값을 설정한다.
-	 * @param sUserSe String
-	 */
-	public void setSUserSe(String userSe) {
-		sUserSe = userSe;
-	}
-	/**
-	 * orgnztId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getOrgnztId() {
-		return orgnztId;
-	}
-	/**
-	 * orgnztId attribute 값을 설정한다.
-	 * @param orgnztId String
-	 */
-	public void setOrgnztId(String orgnztId) {
-		this.orgnztId = orgnztId;
-	}
-	/**
-	 * uniqId attribute 를 리턴한다.
-	 * @return String
-	 */
-	public String getUniqId() {
-		return uniqId;
-	}
-	/**
-	 * uniqId attribute 값을 설정한다.
-	 * @param uniqId String
-	 */
-	public void setUniqId(String uniqId) {
-		this.uniqId = uniqId;
-	}
 }


### PR DESCRIPTION
## 변경 사유

SessionVO 클래스에 수작업으로 작성된 getter/setter 메서드를 Lombok 어노테이션으로 대체하여 보일러플레이트 코드를 줄입니다.

## 변경 내용

- src/main/java/egovframework/com/cmm/SessionVO.java
  - @Getter, @Setter 어노테이션 추가
  - 수작업 getter/setter 메서드 6쌍 제거 (84줄 감소)

## 영향 범위

- SessionVO의 getter/setter 메서드명은 Lombok 생성 메서드명과 동일하므로 기존 호출부 영향 없음
- 빌드 컴파일 확인 완료

## 체크리스트

- [x] 단일 주제만 다룸 (SessionVO 한 파일)
- [x] 기존 동작에 영향 없음
- [x] 빌드 통과 확인