### PR TITLE
[refactor][enterprise] sym/ccm 공통코드 XML 매퍼 @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/let/sym/ccm/cca/service/impl/CmmnCodeMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/cca/service/impl/CmmnCodeMapper.java
@@ -2,15 +2,13 @@ package egovframework.let.sym.ccm.cca.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sym.ccm.cca.service.CmmnCode;
 import egovframework.let.sym.ccm.cca.service.CmmnCodeVO;
-import jakarta.annotation.Resource;
 
 /**
- *
- * 공통코드에 대한 데이터 접근 클래스를 정의한다
+ * 공통코드 MyBatis 매퍼 인터페이스
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
@@ -27,65 +25,46 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("CmmnCodeManageDAO")
-public class CmmnCodeManageDAO {
-
-	@Resource(name = "cmmnCodeMapper")
-	private CmmnCodeMapper cmmnCodeMapper;
+@EgovMapper("cmmnCodeMapper")
+public interface CmmnCodeMapper {
 
 	/**
 	 * 공통코드를 삭제한다.
 	 * @param cmmnCode
-	 * @throws Exception
 	 */
-	public void deleteCmmnCode(CmmnCode cmmnCode) throws Exception {
-		cmmnCodeMapper.deleteCmmnCode(cmmnCode);
-	}
+	void deleteCmmnCode(CmmnCode cmmnCode);
 
 	/**
 	 * 공통코드를 등록한다.
 	 * @param cmmnCode
-	 * @throws Exception
 	 */
-	public void insertCmmnCode(CmmnCode cmmnCode) throws Exception {
-		cmmnCodeMapper.insertCmmnCode(cmmnCode);
-	}
+	void insertCmmnCode(CmmnCode cmmnCode);
 
 	/**
 	 * 공통코드 상세항목을 조회한다.
 	 * @param cmmnCode
 	 * @return CmmnCode(공통코드)
 	 */
-	public CmmnCode selectCmmnCodeDetail(CmmnCode cmmnCode) throws Exception {
-		return cmmnCodeMapper.selectCmmnCodeDetail(cmmnCode);
-	}
+	CmmnCode selectCmmnCodeDetail(CmmnCode cmmnCode);
 
 	/**
 	 * 공통코드 목록을 조회한다.
 	 * @param searchVO
 	 * @return List(공통코드 목록)
-	 * @throws Exception
 	 */
-	public List<?> selectCmmnCodeList(CmmnCodeVO searchVO) throws Exception {
-		return cmmnCodeMapper.selectCmmnCodeList(searchVO);
-	}
+	List<?> selectCmmnCodeList(CmmnCodeVO searchVO);
 
 	/**
 	 * 공통코드 총 갯수를 조회한다.
 	 * @param searchVO
 	 * @return int(공통코드 총 갯수)
 	 */
-	public int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO) throws Exception {
-		return cmmnCodeMapper.selectCmmnCodeListTotCnt(searchVO);
-	}
+	int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO);
 
 	/**
 	 * 공통코드를 수정한다.
 	 * @param cmmnCode
-	 * @throws Exception
 	 */
-	public void updateCmmnCode(CmmnCode cmmnCode) throws Exception {
-		cmmnCodeMapper.updateCmmnCode(cmmnCode);
-	}
+	void updateCmmnCode(CmmnCode cmmnCode);
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/ccc/service/impl/CmmnClCodeMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/ccc/service/impl/CmmnClCodeMapper.java
@@ -2,15 +2,13 @@ package egovframework.let.sym.ccm.ccc.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sym.ccm.ccc.service.CmmnClCode;
 import egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO;
-import jakarta.annotation.Resource;
 
 /**
- *
- * 공통분류코드에 대한 데이터 접근 클래스를 정의한다
+ * 공통분류코드 MyBatis 매퍼 인터페이스
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
@@ -27,65 +25,46 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("CmmnClCodeManageDAO")
-public class CmmnClCodeManageDAO {
-
-	@Resource(name = "cmmnClCodeMapper")
-	private CmmnClCodeMapper cmmnClCodeMapper;
+@EgovMapper("cmmnClCodeMapper")
+public interface CmmnClCodeMapper {
 
 	/**
 	 * 공통분류코드를 삭제한다.
 	 * @param cmmnClCode
-	 * @throws Exception
 	 */
-	public void deleteCmmnClCode(CmmnClCode cmmnClCode) throws Exception {
-		cmmnClCodeMapper.deleteCmmnClCode(cmmnClCode);
-	}
+	void deleteCmmnClCode(CmmnClCode cmmnClCode);
 
 	/**
 	 * 공통분류코드를 등록한다.
 	 * @param cmmnClCode
-	 * @throws Exception
 	 */
-	public void insertCmmnClCode(CmmnClCode cmmnClCode) throws Exception {
-		cmmnClCodeMapper.insertCmmnClCode(cmmnClCode);
-	}
+	void insertCmmnClCode(CmmnClCode cmmnClCode);
 
 	/**
 	 * 공통분류코드 상세항목을 조회한다.
 	 * @param cmmnClCode
 	 * @return CmmnClCode(공통분류코드)
 	 */
-	public CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode) {
-		return cmmnClCodeMapper.selectCmmnClCodeDetail(cmmnClCode);
-	}
+	CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode);
 
 	/**
 	 * 공통분류코드 목록을 조회한다.
 	 * @param searchVO
 	 * @return List(공통분류코드 목록)
-	 * @throws Exception
 	 */
-	public List<?> selectCmmnClCodeList(CmmnClCodeVO searchVO) throws Exception {
-		return cmmnClCodeMapper.selectCmmnClCodeList(searchVO);
-	}
+	List<?> selectCmmnClCodeList(CmmnClCodeVO searchVO);
 
 	/**
 	 * 공통분류코드 총 갯수를 조회한다.
 	 * @param searchVO
 	 * @return int(공통분류코드 총 갯수)
 	 */
-	public int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO) throws Exception {
-		return cmmnClCodeMapper.selectCmmnClCodeListTotCnt(searchVO);
-	}
+	int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO);
 
 	/**
 	 * 공통분류코드를 수정한다.
 	 * @param cmmnClCode
-	 * @throws Exception
 	 */
-	public void updateCmmnClCode(CmmnClCode cmmnClCode) throws Exception {
-		cmmnClCodeMapper.updateCmmnClCode(cmmnClCode);
-	}
+	void updateCmmnClCode(CmmnClCode cmmnClCode);
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeManageDAO.java
+++ b/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sym.ccm.cde.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.CmmnDetailCode;
 import egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO;
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -23,11 +23,15 @@ import egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO;
  *  -------    --------    ---------------------------
  *   2009.04.01  이중호          최초 생성
  *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2025.05.28  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
  *
  * </pre>
  */
 @Repository("CmmnDetailCodeManageDAO")
-public class CmmnDetailCodeManageDAO extends EgovAbstractMapper {
+public class CmmnDetailCodeManageDAO {
+
+	@Resource(name = "cmmnDetailCodeMapper")
+	private CmmnDetailCodeMapper cmmnDetailCodeMapper;
 
 	/**
 	 * 공통상세코드를 삭제한다.
@@ -35,9 +39,8 @@ public class CmmnDetailCodeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void deleteCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception {
-		delete("CmmnDetailCodeManageDAO.deleteCmmnDetailCode", cmmnDetailCode);
+		cmmnDetailCodeMapper.deleteCmmnDetailCode(cmmnDetailCode);
 	}
-
 
 	/**
 	 * 공통상세코드를 등록한다.
@@ -45,7 +48,7 @@ public class CmmnDetailCodeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void insertCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception {
-        insert("CmmnDetailCodeManageDAO.insertCmmnDetailCode", cmmnDetailCode);
+		cmmnDetailCodeMapper.insertCmmnDetailCode(cmmnDetailCode);
 	}
 
 	/**
@@ -54,28 +57,27 @@ public class CmmnDetailCodeManageDAO extends EgovAbstractMapper {
 	 * @return CmmnDetailCode(공통상세코드)
 	 */
 	public CmmnDetailCode selectCmmnDetailCodeDetail(CmmnDetailCode cmmnDetailCode) throws Exception {
-		return (CmmnDetailCode) selectOne("CmmnDetailCodeManageDAO.selectCmmnDetailCodeDetail", cmmnDetailCode);
+		return cmmnDetailCodeMapper.selectCmmnDetailCodeDetail(cmmnDetailCode);
 	}
 
-
-    /**
+	/**
 	 * 공통상세코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(공통상세코드 목록)
-     * @throws Exception
-     */
+	 * @param searchVO
+	 * @return List(공통상세코드 목록)
+	 * @throws Exception
+	 */
 	public List<?> selectCmmnDetailCodeList(CmmnDetailCodeVO searchVO) throws Exception {
-        return selectList("CmmnDetailCodeManageDAO.selectCmmnDetailCodeList", searchVO);
-    }
+		return cmmnDetailCodeMapper.selectCmmnDetailCodeList(searchVO);
+	}
 
-    /**
+	/**
 	 * 공통상세코드 총 갯수를 조회한다.
-     * @param searchVO
-     * @return int(공통상세코드 총 갯수)
-     */
-    public int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception {
-        return (Integer)selectOne("CmmnDetailCodeManageDAO.selectCmmnDetailCodeListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(공통상세코드 총 갯수)
+	 */
+	public int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception {
+		return cmmnDetailCodeMapper.selectCmmnDetailCodeListTotCnt(searchVO);
+	}
 
 	/**
 	 * 공통상세코드를 수정한다.
@@ -83,7 +85,7 @@ public class CmmnDetailCodeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void updateCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception {
-		update("CmmnDetailCodeManageDAO.updateCmmnDetailCode", cmmnDetailCode);
+		cmmnDetailCodeMapper.updateCmmnDetailCode(cmmnDetailCode);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeMapper.java
@@ -1,0 +1,70 @@
+package egovframework.let.sym.ccm.cde.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.service.CmmnDetailCode;
+import egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO;
+
+/**
+ * 공통상세코드 MyBatis 매퍼 인터페이스
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *   2025.05.28  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
+ *
+ * </pre>
+ */
+@EgovMapper("cmmnDetailCodeMapper")
+public interface CmmnDetailCodeMapper {
+
+	/**
+	 * 공통상세코드를 삭제한다.
+	 * @param cmmnDetailCode
+	 */
+	void deleteCmmnDetailCode(CmmnDetailCode cmmnDetailCode);
+
+	/**
+	 * 공통상세코드를 등록한다.
+	 * @param cmmnDetailCode
+	 */
+	void insertCmmnDetailCode(CmmnDetailCode cmmnDetailCode);
+
+	/**
+	 * 공통상세코드 상세항목을 조회한다.
+	 * @param cmmnDetailCode
+	 * @return CmmnDetailCode(공통상세코드)
+	 */
+	CmmnDetailCode selectCmmnDetailCodeDetail(CmmnDetailCode cmmnDetailCode);
+
+	/**
+	 * 공통상세코드 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(공통상세코드 목록)
+	 */
+	List<?> selectCmmnDetailCodeList(CmmnDetailCodeVO searchVO);
+
+	/**
+	 * 공통상세코드 총 갯수를 조회한다.
+	 * @param searchVO
+	 * @return int(공통상세코드 총 갯수)
+	 */
+	int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO);
+
+	/**
+	 * 공통상세코드를 수정한다.
+	 * @param cmmnDetailCode
+	 */
+	void updateCmmnDetailCode(CmmnDetailCode cmmnDetailCode);
+
+}

--- a/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipMapper.java
@@ -2,15 +2,13 @@ package egovframework.let.sym.ccm.zip.service.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
 
 import egovframework.let.sym.ccm.zip.service.Zip;
 import egovframework.let.sym.ccm.zip.service.ZipVO;
-import jakarta.annotation.Resource;
 
 /**
- *
- * 우편번호에 대한 데이터 접근 클래스를 정의한다
+ * 우편번호 MyBatis 매퍼 인터페이스
  * @author 공통서비스 개발팀 이중호
  * @since 2009.04.01
  * @version 1.0
@@ -27,81 +25,56 @@ import jakarta.annotation.Resource;
  *
  * </pre>
  */
-@Repository("ZipManageDAO")
-public class ZipManageDAO {
-
-	@Resource(name = "zipMapper")
-	private ZipMapper zipMapper;
+@EgovMapper("zipMapper")
+public interface ZipMapper {
 
 	/**
 	 * 우편번호를 삭제한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void deleteZip(Zip zip) throws Exception {
-		zipMapper.deleteZip(zip);
-	}
+	void deleteZip(Zip zip);
 
 	/**
 	 * 우편번호 전체를 삭제한다.
-	 * @throws Exception
 	 */
-	public void deleteAllZip() throws Exception {
-		zipMapper.deleteAllZip();
-	}
+	void deleteAllZip();
 
 	/**
 	 * 우편번호를 등록한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void insertZip(Zip zip) throws Exception {
-		zipMapper.insertZip(zip);
-	}
+	void insertZip(Zip zip);
 
 	/**
 	 * 우편번호 엑셀파일을 등록한다.
-	 * @throws Exception
 	 */
-	public void insertExcelZip() throws Exception {
-		zipMapper.insertExcelZip();
-	}
+	void insertExcelZip();
 
 	/**
 	 * 우편번호 상세항목을 조회한다.
 	 * @param zip
 	 * @return Zip(우편번호)
 	 */
-	public Zip selectZipDetail(Zip zip) throws Exception {
-		return zipMapper.selectZipDetail(zip);
-	}
+	Zip selectZipDetail(Zip zip);
 
 	/**
 	 * 우편번호 목록을 조회한다.
 	 * @param searchVO
 	 * @return List(우편번호 목록)
-	 * @throws Exception
 	 */
-	public List<?> selectZipList(ZipVO searchVO) throws Exception {
-		return zipMapper.selectZipList(searchVO);
-	}
+	List<?> selectZipList(ZipVO searchVO);
 
 	/**
 	 * 우편번호 총 갯수를 조회한다.
 	 * @param searchVO
 	 * @return int(우편번호 총 갯수)
 	 */
-	public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
-		return zipMapper.selectZipListTotCnt(searchVO);
-	}
+	int selectZipListTotCnt(ZipVO searchVO);
 
 	/**
 	 * 우편번호를 수정한다.
 	 * @param zip
-	 * @throws Exception
 	 */
-	public void updateZip(Zip zip) throws Exception {
-		zipMapper.updateZip(zip);
-	}
+	void updateZip(Zip zip);
 
 }

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">


### PR DESCRIPTION
sym/ccm 패키지(공통분류코드/공통코드/공통상세코드/우편번호) 4개 DAO의 MyBatis 매퍼를 EgovAbstractMapper 상속 방식에서 @EgovMapper 인터페이스 방식으로 전환했습니다.

변경 내용:
- CmmnClCodeMapper, CmmnCodeMapper, CmmnDetailCodeMapper, ZipMapper 인터페이스 신설
- XML mapper namespace를 각 인터페이스의 FQN으로 변경 (6개 DB 방언 × 4 = 24개 파일)
- 각 DAO에서 EgovAbstractMapper 상속 제거, @Resource로 Mapper 인터페이스 주입
- SQL 변경 없음

- [ ] 단일 주제만 다룸 (다른 변경 없음)
- [ ] 기존 동작에 영향 없음 (SQL 변경 없이 매퍼 방식만 전환)
- [ ] mvn compile 통과 확인
