### PR TITLE
[refactor][enterprise] cmm/FileManageDAO, CmmUseDAO @EgovMapper 인터페이스 방식으로 전환

### DIFF
--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseDAO.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultCodeVO;
 import egovframework.com.cmm.service.CmmnDetailCode;
+import jakarta.annotation.Resource;
 
 /**
  * @Class Name : CmmUseDAO.java
@@ -14,16 +15,20 @@ import egovframework.com.cmm.service.CmmnDetailCode;
  *
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
- *    2009. 3. 11.     이삼섭
+ *    2009. 3. 11.     이삼섭    최초생성
+ *    2024.11.01  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 11.
- * @version
+ * @version 2.0
  * @see
  *
  */
 @Repository("cmmUseDAO")
-public class CmmUseDAO extends EgovComAbstractDAO {
+public class CmmUseDAO {
+
+	@Resource(name = "cmmUseDAO")
+	private CmmUseMapper cmmUseMapper;
 
     /**
      * 주어진 조건에 따른 공통코드를 불러온다.
@@ -33,7 +38,7 @@ public class CmmUseDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
 	public List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO vo) throws Exception {
-		return selectList("CmmUseDAO.selectCmmCodeDetail", vo);
+		return cmmUseMapper.selectCmmCodeDetail(vo);
     }
 
     /**
@@ -44,7 +49,7 @@ public class CmmUseDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO vo) throws Exception {
-    	return selectList("CmmUseDAO.selectOgrnztIdDetail", vo);
+    	return cmmUseMapper.selectOgrnztIdDetail(vo);
     }
 
     /**
@@ -55,6 +60,6 @@ public class CmmUseDAO extends EgovComAbstractDAO {
      * @throws Exception
      */
     public List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO vo) throws Exception {
-    	return selectList("CmmUseDAO.selectGroupIdDetail", vo);
+    	return cmmUseMapper.selectGroupIdDetail(vo);
     }
 }

--- a/src/main/java/egovframework/com/cmm/service/impl/CmmUseMapper.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/CmmUseMapper.java
@@ -1,0 +1,53 @@
+package egovframework.com.cmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultCodeVO;
+import egovframework.com.cmm.service.CmmnDetailCode;
+
+/**
+ * @Class Name : CmmUseMapper.java
+ * @Description : 공통코드 등 전체 업무에서 공용으로 사용하는 서비스를 위한 Mapper 인터페이스
+ * @Modification Information
+ *
+ *    수정일       수정자         수정내용
+ *    -------        -------     -------------------
+ *    2009. 3. 11.     이삼섭    최초생성
+ *    2024.11.01  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009. 3. 11.
+ * @version 2.0
+ * @see
+ *
+ */
+@EgovMapper("cmmUseDAO")
+public interface CmmUseMapper {
+
+	/**
+	 * 주어진 조건에 따른 공통코드를 불러온다.
+	 * @param vo ComDefaultCodeVO
+	 * @return List&lt;CmmnDetailCode&gt;
+	 * @exception Exception
+	 */
+	List<CmmnDetailCode> selectCmmCodeDetail(ComDefaultCodeVO vo) throws Exception;
+
+	/**
+	 * 공통코드로 사용할 조직정보를 불러온다.
+	 * @param vo ComDefaultCodeVO
+	 * @return List&lt;CmmnDetailCode&gt;
+	 * @exception Exception
+	 */
+	List<CmmnDetailCode> selectOgrnztIdDetail(ComDefaultCodeVO vo) throws Exception;
+
+	/**
+	 * 공통코드로 사용할 그룹정보를 불러온다.
+	 * @param vo ComDefaultCodeVO
+	 * @return List&lt;CmmnDetailCode&gt;
+	 * @exception Exception
+	 */
+	List<CmmnDetailCode> selectGroupIdDetail(ComDefaultCodeVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileManageDAO.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.FileVO;
+import jakarta.annotation.Resource;
 
 /**
  * @Class Name : EgovFileMngDAO.java
@@ -15,15 +16,19 @@ import egovframework.com.cmm.service.FileVO;
  *    수정일       수정자         수정내용
  *    -------        -------     -------------------
  *    2009. 3. 25.     이삼섭    최초생성
+ *    2024.11.01  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
  *
  * @author 공통 서비스 개발팀 이삼섭
  * @since 2009. 3. 25.
- * @version
+ * @version 2.0
  * @see
  *
  */
 @Repository("FileManageDAO")
-public class FileManageDAO extends EgovComAbstractDAO {
+public class FileManageDAO {
+
+	@Resource(name = "FileManageDAO")
+	private FileManageMapper fileManageMapper;
 
 	/**
 	 * 여러 개의 파일에 대한 정보(속성 및 상세)를 등록한다.
@@ -36,13 +41,13 @@ public class FileManageDAO extends EgovComAbstractDAO {
 		FileVO vo = (FileVO) fileList.get(0);
 		String atchFileId = vo.getAtchFileId();
 
-		insert("FileManageDAO.insertFileMaster", vo);
+		fileManageMapper.insertFileMaster(vo);
 
 		Iterator<?> iter = fileList.iterator();
 		while (iter.hasNext()) {
 			vo = (FileVO) iter.next();
 
-			insert("FileManageDAO.insertFileDetail", vo);
+			fileManageMapper.insertFileDetail(vo);
 		}
 
 		return atchFileId;
@@ -55,8 +60,8 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void insertFileInf(FileVO vo) throws Exception {
-		insert("FileManageDAO.insertFileMaster", vo);
-		insert("FileManageDAO.insertFileDetail", vo);
+		fileManageMapper.insertFileMaster(vo);
+		fileManageMapper.insertFileDetail(vo);
 	}
 
 	/**
@@ -71,7 +76,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 		while (iter.hasNext()) {
 			vo = (FileVO) iter.next();
 
-			insert("FileManageDAO.insertFileDetail", vo);
+			fileManageMapper.insertFileDetail(vo);
 		}
 	}
 
@@ -87,7 +92,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 		while (iter.hasNext()) {
 			vo = (FileVO) iter.next();
 
-			delete("FileManageDAO.deleteFileDetail", vo);
+			fileManageMapper.deleteFileDetail(vo);
 		}
 	}
 
@@ -98,7 +103,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteFileInf(FileVO fvo) throws Exception {
-		delete("FileManageDAO.deleteFileDetail", fvo);
+		fileManageMapper.deleteFileDetail(fvo);
 	}
 
 	/**
@@ -109,7 +114,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<FileVO> selectFileInfs(FileVO vo) throws Exception {
-		return selectList("FileManageDAO.selectFileList", vo);
+		return fileManageMapper.selectFileList(vo);
 	}
 
 	/**
@@ -120,7 +125,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public int getMaxFileSN(FileVO fvo) throws Exception {
-		return (Integer) selectOne("FileManageDAO.getMaxFileSN", fvo);
+		return fileManageMapper.getMaxFileSN(fvo);
 	}
 
 	/**
@@ -131,7 +136,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public FileVO selectFileInf(FileVO fvo) throws Exception {
-		return (FileVO) selectOne("FileManageDAO.selectFileInf", fvo);
+		return fileManageMapper.selectFileInf(fvo);
 	}
 
 	/**
@@ -141,18 +146,18 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public void deleteAllFileInf(FileVO fvo) throws Exception {
-		update("FileManageDAO.deleteCOMTNFILE", fvo);
+		fileManageMapper.deleteCOMTNFILE(fvo);
 	}
 
 	/**
 	 * 파일명 검색에 대한 목록을 조회한다.
 	 *
-	 * @param vo
+	 * @param fvo
 	 * @return
 	 * @throws Exception
 	 */
 	public List<FileVO> selectFileListByFileNm(FileVO fvo) throws Exception {
-		return selectList("FileManageDAO.selectFileListByFileNm", fvo);
+		return fileManageMapper.selectFileListByFileNm(fvo);
 	}
 
 	/**
@@ -163,7 +168,7 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public int selectFileListCntByFileNm(FileVO fvo) throws Exception {
-		return (Integer) selectOne("FileManageDAO.selectFileListCntByFileNm", fvo);
+		return fileManageMapper.selectFileListCntByFileNm(fvo);
 	}
 
 	/**
@@ -174,6 +179,6 @@ public class FileManageDAO extends EgovComAbstractDAO {
 	 * @throws Exception
 	 */
 	public List<FileVO> selectImageFileList(FileVO vo) throws Exception {
-		return selectList("FileManageDAO.selectImageFileList", vo);
+		return fileManageMapper.selectImageFileList(vo);
 	}
 }

--- a/src/main/java/egovframework/com/cmm/service/impl/FileManageMapper.java
+++ b/src/main/java/egovframework/com/cmm/service/impl/FileManageMapper.java
@@ -1,0 +1,104 @@
+package egovframework.com.cmm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.service.FileVO;
+
+/**
+ * @Class Name : FileManageMapper.java
+ * @Description : 파일정보 관리를 위한 Mapper 인터페이스
+ * @Modification Information
+ *
+ *    수정일       수정자         수정내용
+ *    -------        -------     -------------------
+ *    2009. 3. 25.     이삼섭    최초생성
+ *    2024.11.01  표준프레임워크센터  @EgovMapper 어노테이션 방식으로 전환
+ *
+ * @author 공통 서비스 개발팀 이삼섭
+ * @since 2009. 3. 25.
+ * @version 2.0
+ * @see
+ *
+ */
+@EgovMapper("FileManageDAO")
+public interface FileManageMapper {
+
+	/**
+	 * 여러 개의 파일 마스터를 등록한다.
+	 * @param vo FileVO
+	 * @exception Exception
+	 */
+	void insertFileMaster(FileVO vo) throws Exception;
+
+	/**
+	 * 파일 상세정보를 등록한다.
+	 * @param vo FileVO
+	 * @exception Exception
+	 */
+	void insertFileDetail(FileVO vo) throws Exception;
+
+	/**
+	 * 파일 상세정보를 삭제한다.
+	 * @param vo FileVO
+	 * @exception Exception
+	 */
+	void deleteFileDetail(FileVO vo) throws Exception;
+
+	/**
+	 * 파일에 대한 목록을 조회한다.
+	 * @param vo FileVO
+	 * @return List&lt;FileVO&gt;
+	 * @exception Exception
+	 */
+	List<FileVO> selectFileList(FileVO vo) throws Exception;
+
+	/**
+	 * 파일 구분자에 대한 최대값을 구한다.
+	 * @param fvo FileVO
+	 * @return int
+	 * @exception Exception
+	 */
+	int getMaxFileSN(FileVO fvo) throws Exception;
+
+	/**
+	 * 파일에 대한 상세정보를 조회한다.
+	 * @param fvo FileVO
+	 * @return FileVO
+	 * @exception Exception
+	 */
+	FileVO selectFileInf(FileVO fvo) throws Exception;
+
+	/**
+	 * 전체 파일을 삭제(USE_AT = 'N')한다.
+	 * @param fvo FileVO
+	 * @exception Exception
+	 */
+	void deleteCOMTNFILE(FileVO fvo) throws Exception;
+
+	/**
+	 * 파일명 검색에 대한 목록을 조회한다.
+	 * @param fvo FileVO
+	 * @return List&lt;FileVO&gt;
+	 * @exception Exception
+	 */
+	List<FileVO> selectFileListByFileNm(FileVO fvo) throws Exception;
+
+	/**
+	 * 파일명 검색에 대한 목록 전체 건수를 조회한다.
+	 * @param fvo FileVO
+	 * @return int
+	 * @exception Exception
+	 */
+	int selectFileListCntByFileNm(FileVO fvo) throws Exception;
+
+	/**
+	 * 이미지 파일에 대한 목록을 조회한다.
+	 * @param vo FileVO
+	 * @return List&lt;FileVO&gt;
+	 * @exception Exception
+	 */
+	List<FileVO> selectImageFileList(FileVO vo) throws Exception;
+
+}

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileManageMapper">
 
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileManageMapper">
 
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileManageMapper">
 
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileManageMapper">
 
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileManageMapper">
 
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">

--- a/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/fms/EgovFile_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="FileManageDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.FileManageMapper">
 
 
 	<resultMap id="fileList" type="egovframework.com.cmm.service.FileVO">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">

--- a/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/cmm/use/EgovCmmUse_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmUseDAO">
+<mapper namespace="egovframework.com.cmm.service.impl.CmmUseMapper">
 
 
 	<resultMap id="CmmCodeDetail" type="egovframework.com.cmm.service.CmmnDetailCode">


### PR DESCRIPTION
eGovFrame 5.0에 반영된 `@EgovMapper` 어노테이션 방식을 활용하여 `cmm` 패키지의 `FileManageDAO`와 `CmmUseDAO`를 sqlSession 문자열 기반 호출에서 타입 안전한 인터페이스 방식으로 전환합니다.

## 변경 내용

**신규 생성**
- `FileManageMapper` 인터페이스 (`@EgovMapper("FileManageDAO")` 적용)
- `CmmUseMapper` 인터페이스 (`@EgovMapper("cmmUseDAO")` 적용)

**수정**
- `FileManageDAO`: `EgovComAbstractDAO` 상속 제거 → `FileManageMapper` `@Resource` 주입
- `CmmUseDAO`: `EgovComAbstractDAO` 상속 제거 → `CmmUseMapper` `@Resource` 주입
- XML 매퍼 12개(fms 6개, use 6개) namespace를 인터페이스 FQN으로 변경 (SQL 내용 변경 없음)

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (메서드 시그니처 동일, SQL 내용 동일)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시
