### PR TITLE
[refactor][공통컴포넌트] sym·uat·uss 12개 DAO @EgovMapper 인터페이스 전환

### DIFF
--- a/src/main/java/egovframework/let/sym/ccm/cca/service/impl/CmmnCodeManageDAO.java
+++ b/src/main/java/egovframework/let/sym/ccm/cca/service/impl/CmmnCodeManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sym.ccm.cca.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.ccm.cca.service.CmmnCode;
 import egovframework.let.sym.ccm.cca.service.CmmnCodeVO;
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -27,7 +27,10 @@ import egovframework.let.sym.ccm.cca.service.CmmnCodeVO;
  * </pre>
  */
 @Repository("CmmnCodeManageDAO")
-public class CmmnCodeManageDAO extends EgovAbstractMapper {
+public class CmmnCodeManageDAO {
+
+	@Resource(name = "cmmnCodeManageMapper")
+	private CmmnCodeManageMapper cmmnCodeManageMapper;
 
 	/**
 	 * 공통코드를 삭제한다.
@@ -35,9 +38,8 @@ public class CmmnCodeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void deleteCmmnCode(CmmnCode cmmnCode) throws Exception {
-		delete("CmmnCodeManageDAO.deleteCmmnCode", cmmnCode);
+		cmmnCodeManageMapper.deleteCmmnCode(cmmnCode);
 	}
-
 
 	/**
 	 * 공통코드를 등록한다.
@@ -45,37 +47,38 @@ public class CmmnCodeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void insertCmmnCode(CmmnCode cmmnCode) throws Exception {
-        insert("CmmnCodeManageDAO.insertCmmnCode", cmmnCode);
+		cmmnCodeManageMapper.insertCmmnCode(cmmnCode);
 	}
 
 	/**
 	 * 공통코드 상세항목을 조회한다.
 	 * @param cmmnCode
 	 * @return CmmnCode(공통코드)
+	 * @throws Exception
 	 */
 	public CmmnCode selectCmmnCodeDetail(CmmnCode cmmnCode) throws Exception {
-		return (CmmnCode)selectOne("CmmnCodeManageDAO.selectCmmnCodeDetail", cmmnCode);
+		return cmmnCodeManageMapper.selectCmmnCodeDetail(cmmnCode);
 	}
 
-
-    /**
+	/**
 	 * 공통코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(공통코드 목록)
-     * @throws Exception
-     */
+	 * @param searchVO
+	 * @return List(공통코드 목록)
+	 * @throws Exception
+	 */
 	public List<?> selectCmmnCodeList(CmmnCodeVO searchVO) throws Exception {
-        return selectList("CmmnCodeManageDAO.selectCmmnCodeList", searchVO);
-    }
+		return cmmnCodeManageMapper.selectCmmnCodeList(searchVO);
+	}
 
-    /**
+	/**
 	 * 공통코드 총 갯수를 조회한다.
-     * @param searchVO
-     * @return int(공통코드 총 갯수)
-     */
-    public int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO) throws Exception {
-        return (Integer)selectOne("CmmnCodeManageDAO.selectCmmnCodeListTotCnt", searchVO);
-    }
+	 * @param searchVO
+	 * @return int(공통코드 총 갯수)
+	 * @throws Exception
+	 */
+	public int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO) throws Exception {
+		return cmmnCodeManageMapper.selectCmmnCodeListTotCnt(searchVO);
+	}
 
 	/**
 	 * 공통코드를 수정한다.
@@ -83,7 +86,7 @@ public class CmmnCodeManageDAO extends EgovAbstractMapper {
 	 * @throws Exception
 	 */
 	public void updateCmmnCode(CmmnCode cmmnCode) throws Exception {
-		update("CmmnCodeManageDAO.updateCmmnCode", cmmnCode);
+		cmmnCodeManageMapper.updateCmmnCode(cmmnCode);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/cca/service/impl/CmmnCodeManageMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/cca/service/impl/CmmnCodeManageMapper.java
@@ -1,0 +1,76 @@
+package egovframework.let.sym.ccm.cca.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.ccm.cca.service.CmmnCode;
+import egovframework.let.sym.ccm.cca.service.CmmnCodeVO;
+
+/**
+ *
+ * 공통코드에 대한 Mapper 인터페이스를 정의한다
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface CmmnCodeManageMapper {
+
+	/**
+	 * 공통코드를 삭제한다.
+	 * @param cmmnCode
+	 * @throws Exception
+	 */
+	void deleteCmmnCode(CmmnCode cmmnCode) throws Exception;
+
+	/**
+	 * 공통코드를 등록한다.
+	 * @param cmmnCode
+	 * @throws Exception
+	 */
+	void insertCmmnCode(CmmnCode cmmnCode) throws Exception;
+
+	/**
+	 * 공통코드 상세항목을 조회한다.
+	 * @param cmmnCode
+	 * @return CmmnCode(공통코드)
+	 * @throws Exception
+	 */
+	CmmnCode selectCmmnCodeDetail(CmmnCode cmmnCode) throws Exception;
+
+	/**
+	 * 공통코드 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(공통코드 목록)
+	 * @throws Exception
+	 */
+	List<?> selectCmmnCodeList(CmmnCodeVO searchVO) throws Exception;
+
+	/**
+	 * 공통코드 총 갯수를 조회한다.
+	 * @param searchVO
+	 * @return int(공통코드 총 갯수)
+	 * @throws Exception
+	 */
+	int selectCmmnCodeListTotCnt(CmmnCodeVO searchVO) throws Exception;
+
+	/**
+	 * 공통코드를 수정한다.
+	 * @param cmmnCode
+	 * @throws Exception
+	 */
+	void updateCmmnCode(CmmnCode cmmnCode) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/ccm/ccc/service/impl/CmmnClCodeManageDAO.java
+++ b/src/main/java/egovframework/let/sym/ccm/ccc/service/impl/CmmnClCodeManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sym.ccm.ccc.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.ccm.ccc.service.CmmnClCode;
 import egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO;
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -27,63 +27,33 @@ import egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO;
  * </pre>
  */
 @Repository("CmmnClCodeManageDAO")
-public class CmmnClCodeManageDAO extends EgovAbstractMapper {
+public class CmmnClCodeManageDAO {
 
-	/**
-	 * 공통분류코드를 삭제한다.
-	 * @param cmmnClCode
-	 * @throws Exception
-	 */
+	@Resource(name = "cmmnClCodeManageMapper")
+	private CmmnClCodeManageMapper cmmnClCodeManageMapper;
+
 	public void deleteCmmnClCode(CmmnClCode cmmnClCode) throws Exception {
-		delete("CmmnClCodeManageDAO.deleteCmmnClCode", cmmnClCode);
+		cmmnClCodeManageMapper.deleteCmmnClCode(cmmnClCode);
 	}
 
-
-	/**
-	 * 공통분류코드를 등록한다.
-	 * @param cmmnClCode
-	 * @throws Exception
-	 */
 	public void insertCmmnClCode(CmmnClCode cmmnClCode) throws Exception {
-        insert("CmmnClCodeManageDAO.insertCmmnClCode", cmmnClCode);
+		cmmnClCodeManageMapper.insertCmmnClCode(cmmnClCode);
 	}
 
-	/**
-	 * 공통분류코드 상세항목을 조회한다.
-	 * @param cmmnClCode
-	 * @return CmmnClCode(공통분류코드)
-	 */
 	public CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode) {
-		return (CmmnClCode)selectOne("CmmnClCodeManageDAO.selectCmmnClCodeDetail", cmmnClCode);
+		return cmmnClCodeManageMapper.selectCmmnClCodeDetail(cmmnClCode);
 	}
 
-
-    /**
-	 * 공통분류코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(공통분류코드 목록)
-     * @throws Exception
-     */
 	public List<?> selectCmmnClCodeList(CmmnClCodeVO searchVO) throws Exception {
-        return selectList("CmmnClCodeManageDAO.selectCmmnClCodeList", searchVO);
-    }
+		return cmmnClCodeManageMapper.selectCmmnClCodeList(searchVO);
+	}
 
-    /**
-	 * 공통분류코드 총 갯수를 조회한다.
-     * @param searchVO
-     * @return int(공통분류코드 총 갯수)
-     */
-    public int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO) throws Exception {
-        return (Integer)selectOne("CmmnClCodeManageDAO.selectCmmnClCodeListTotCnt", searchVO);
-    }
+	public int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO) throws Exception {
+		return cmmnClCodeManageMapper.selectCmmnClCodeListTotCnt(searchVO);
+	}
 
-	/**
-	 * 공통분류코드를 수정한다.
-	 * @param cmmnClCode
-	 * @throws Exception
-	 */
 	public void updateCmmnClCode(CmmnClCode cmmnClCode) throws Exception {
-		update("CmmnClCodeManageDAO.updateCmmnClCode", cmmnClCode);
+		cmmnClCodeManageMapper.updateCmmnClCode(cmmnClCode);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/ccc/service/impl/CmmnClCodeManageMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/ccc/service/impl/CmmnClCodeManageMapper.java
@@ -1,0 +1,75 @@
+package egovframework.let.sym.ccm.ccc.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.ccm.ccc.service.CmmnClCode;
+import egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO;
+
+/**
+ *
+ * 공통분류코드에 대한 Mapper 인터페이스를 정의한다
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface CmmnClCodeManageMapper {
+
+	/**
+	 * 공통분류코드를 삭제한다.
+	 * @param cmmnClCode
+	 * @throws Exception
+	 */
+	void deleteCmmnClCode(CmmnClCode cmmnClCode) throws Exception;
+
+	/**
+	 * 공통분류코드를 등록한다.
+	 * @param cmmnClCode
+	 * @throws Exception
+	 */
+	void insertCmmnClCode(CmmnClCode cmmnClCode) throws Exception;
+
+	/**
+	 * 공통분류코드 상세항목을 조회한다.
+	 * @param cmmnClCode
+	 * @return CmmnClCode(공통분류코드)
+	 */
+	CmmnClCode selectCmmnClCodeDetail(CmmnClCode cmmnClCode);
+
+	/**
+	 * 공통분류코드 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(공통분류코드 목록)
+	 * @throws Exception
+	 */
+	List<?> selectCmmnClCodeList(CmmnClCodeVO searchVO) throws Exception;
+
+	/**
+	 * 공통분류코드 총 갯수를 조회한다.
+	 * @param searchVO
+	 * @return int(공통분류코드 총 갯수)
+	 * @throws Exception
+	 */
+	int selectCmmnClCodeListTotCnt(CmmnClCodeVO searchVO) throws Exception;
+
+	/**
+	 * 공통분류코드를 수정한다.
+	 * @param cmmnClCode
+	 * @throws Exception
+	 */
+	void updateCmmnClCode(CmmnClCode cmmnClCode) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeManageDAO.java
+++ b/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sym.ccm.cde.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.service.CmmnDetailCode;
 import egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO;
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -27,63 +27,33 @@ import egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO;
  * </pre>
  */
 @Repository("CmmnDetailCodeManageDAO")
-public class CmmnDetailCodeManageDAO extends EgovAbstractMapper {
+public class CmmnDetailCodeManageDAO {
 
-	/**
-	 * 공통상세코드를 삭제한다.
-	 * @param cmmnDetailCode
-	 * @throws Exception
-	 */
+	@Resource(name = "cmmnDetailCodeManageMapper")
+	private CmmnDetailCodeManageMapper cmmnDetailCodeManageMapper;
+
 	public void deleteCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception {
-		delete("CmmnDetailCodeManageDAO.deleteCmmnDetailCode", cmmnDetailCode);
+		cmmnDetailCodeManageMapper.deleteCmmnDetailCode(cmmnDetailCode);
 	}
 
-
-	/**
-	 * 공통상세코드를 등록한다.
-	 * @param cmmnDetailCode
-	 * @throws Exception
-	 */
 	public void insertCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception {
-        insert("CmmnDetailCodeManageDAO.insertCmmnDetailCode", cmmnDetailCode);
+		cmmnDetailCodeManageMapper.insertCmmnDetailCode(cmmnDetailCode);
 	}
 
-	/**
-	 * 공통상세코드 상세항목을 조회한다.
-	 * @param cmmnDetailCode
-	 * @return CmmnDetailCode(공통상세코드)
-	 */
 	public CmmnDetailCode selectCmmnDetailCodeDetail(CmmnDetailCode cmmnDetailCode) throws Exception {
-		return (CmmnDetailCode) selectOne("CmmnDetailCodeManageDAO.selectCmmnDetailCodeDetail", cmmnDetailCode);
+		return cmmnDetailCodeManageMapper.selectCmmnDetailCodeDetail(cmmnDetailCode);
 	}
 
-
-    /**
-	 * 공통상세코드 목록을 조회한다.
-     * @param searchVO
-     * @return List(공통상세코드 목록)
-     * @throws Exception
-     */
 	public List<?> selectCmmnDetailCodeList(CmmnDetailCodeVO searchVO) throws Exception {
-        return selectList("CmmnDetailCodeManageDAO.selectCmmnDetailCodeList", searchVO);
-    }
+		return cmmnDetailCodeManageMapper.selectCmmnDetailCodeList(searchVO);
+	}
 
-    /**
-	 * 공통상세코드 총 갯수를 조회한다.
-     * @param searchVO
-     * @return int(공통상세코드 총 갯수)
-     */
-    public int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception {
-        return (Integer)selectOne("CmmnDetailCodeManageDAO.selectCmmnDetailCodeListTotCnt", searchVO);
-    }
+	public int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception {
+		return cmmnDetailCodeManageMapper.selectCmmnDetailCodeListTotCnt(searchVO);
+	}
 
-	/**
-	 * 공통상세코드를 수정한다.
-	 * @param cmmnDetailCode
-	 * @throws Exception
-	 */
 	public void updateCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception {
-		update("CmmnDetailCodeManageDAO.updateCmmnDetailCode", cmmnDetailCode);
+		cmmnDetailCodeManageMapper.updateCmmnDetailCode(cmmnDetailCode);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeManageMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/cde/service/impl/CmmnDetailCodeManageMapper.java
@@ -1,0 +1,76 @@
+package egovframework.let.sym.ccm.cde.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.service.CmmnDetailCode;
+import egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO;
+
+/**
+ *
+ * 공통상세코드에 대한 Mapper 인터페이스를 정의한다
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface CmmnDetailCodeManageMapper {
+
+	/**
+	 * 공통상세코드를 삭제한다.
+	 * @param cmmnDetailCode
+	 * @throws Exception
+	 */
+	void deleteCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception;
+
+	/**
+	 * 공통상세코드를 등록한다.
+	 * @param cmmnDetailCode
+	 * @throws Exception
+	 */
+	void insertCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception;
+
+	/**
+	 * 공통상세코드 상세항목을 조회한다.
+	 * @param cmmnDetailCode
+	 * @return CmmnDetailCode(공통상세코드)
+	 * @throws Exception
+	 */
+	CmmnDetailCode selectCmmnDetailCodeDetail(CmmnDetailCode cmmnDetailCode) throws Exception;
+
+	/**
+	 * 공통상세코드 목록을 조회한다.
+	 * @param searchVO
+	 * @return List(공통상세코드 목록)
+	 * @throws Exception
+	 */
+	List<?> selectCmmnDetailCodeList(CmmnDetailCodeVO searchVO) throws Exception;
+
+	/**
+	 * 공통상세코드 총 갯수를 조회한다.
+	 * @param searchVO
+	 * @return int(공통상세코드 총 갯수)
+	 * @throws Exception
+	 */
+	int selectCmmnDetailCodeListTotCnt(CmmnDetailCodeVO searchVO) throws Exception;
+
+	/**
+	 * 공통상세코드를 수정한다.
+	 * @param cmmnDetailCode
+	 * @throws Exception
+	 */
+	void updateCmmnDetailCode(CmmnDetailCode cmmnDetailCode) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageDAO.java
+++ b/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.sym.ccm.zip.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.ccm.zip.service.Zip;
 import egovframework.let.sym.ccm.zip.service.ZipVO;
+import jakarta.annotation.Resource;
 
 /**
  *
@@ -27,80 +27,41 @@ import egovframework.let.sym.ccm.zip.service.ZipVO;
  * </pre>
  */
 @Repository("ZipManageDAO")
-public class ZipManageDAO extends EgovAbstractMapper {
+public class ZipManageDAO {
 
-	/**
-	 * 우편번호를 삭제한다.
-	 * @param zip
-	 * @throws Exception
-	 */
+	@Resource(name = "zipManageMapper")
+	private ZipManageMapper zipManageMapper;
+
 	public void deleteZip(Zip zip) throws Exception {
-		delete("ZipManageDAO.deleteZip", zip);
+		zipManageMapper.deleteZip(zip);
 	}
 
-	/**
-	 * 우편번호 전체를 삭제한다.
-	 * @throws Exception
-	 */
 	public void deleteAllZip() throws Exception {
-		delete("ZipManageDAO.deleteAllZip", new Object());
+		zipManageMapper.deleteAllZip();
 	}
 
-	/**
-	 * 우편번호를 등록한다.
-	 * @param zip
-	 * @throws Exception
-	 */
 	public void insertZip(Zip zip) throws Exception {
-        insert("ZipManageDAO.insertZip", zip);
+		zipManageMapper.insertZip(zip);
 	}
 
-	/**
-	 * 우편번호 엑셀파일을 등록한다.
-	 * @param zip
-	 * @throws Exception
-	 */
 	public void insertExcelZip() throws Exception {
-		delete("ZipManageDAO.deleteAllZip", new Object());
+		zipManageMapper.deleteAllZip();
 	}
 
-
-	/**
-	 * 우편번호 상세항목을 조회한다.
-	 * @param zip
-	 * @return Zip(우편번호)
-	 */
 	public Zip selectZipDetail(Zip zip) throws Exception {
-		return (Zip) selectOne("ZipManageDAO.selectZipDetail", zip);
+		return zipManageMapper.selectZipDetail(zip);
 	}
 
-
-    /**
-	 * 우편번호 목록을 조회한다.
-     * @param searchVO
-     * @return List(우편번호 목록)
-     * @throws Exception
-     */
 	public List<?> selectZipList(ZipVO searchVO) throws Exception {
-        return selectList("ZipManageDAO.selectZipList", searchVO);
-    }
+		return zipManageMapper.selectZipList(searchVO);
+	}
 
-    /**
-	 * 우편번호 총 갯수를 조회한다.
-     * @param searchVO
-     * @return int(우편번호 총 갯수)
-     */
-    public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
-        return (Integer)selectOne("ZipManageDAO.selectZipListTotCnt", searchVO);
-    }
+	public int selectZipListTotCnt(ZipVO searchVO) throws Exception {
+		return zipManageMapper.selectZipListTotCnt(searchVO);
+	}
 
-	/**
-	 * 우편번호를 수정한다.
-	 * @param zip
-	 * @throws Exception
-	 */
 	public void updateZip(Zip zip) throws Exception {
-		update("ZipManageDAO.updateZip", zip);
+		zipManageMapper.updateZip(zip);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageMapper.java
+++ b/src/main/java/egovframework/let/sym/ccm/zip/service/impl/ZipManageMapper.java
@@ -1,0 +1,45 @@
+package egovframework.let.sym.ccm.zip.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.ccm.zip.service.Zip;
+import egovframework.let.sym.ccm.zip.service.ZipVO;
+
+/**
+ *
+ * 우편번호에 대한 Mapper 인터페이스를 정의한다
+ * @author 공통서비스 개발팀 이중호
+ * @since 2009.04.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.01  이중호          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface ZipManageMapper {
+
+	void deleteZip(Zip zip) throws Exception;
+
+	void deleteAllZip() throws Exception;
+
+	void insertZip(Zip zip) throws Exception;
+
+	Zip selectZipDetail(Zip zip) throws Exception;
+
+	List<?> selectZipList(ZipVO searchVO) throws Exception;
+
+	int selectZipListTotCnt(ZipVO searchVO) throws Exception;
+
+	void updateZip(Zip zip) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/log/clg/service/impl/LoginLogDAO.java
+++ b/src/main/java/egovframework/let/sym/log/clg/service/impl/LoginLogDAO.java
@@ -2,10 +2,10 @@ package egovframework.let.sym.log.clg.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.log.clg.service.LoginLog;
+import jakarta.annotation.Resource;
 
 /**
  * 시스템 로그 관리를 위한 데이터 접근 클래스
@@ -26,51 +26,25 @@ import egovframework.let.sym.log.clg.service.LoginLog;
  * </pre>
  */
 @Repository("loginLogDAO")
-public class LoginLogDAO extends EgovAbstractMapper {
+public class LoginLogDAO {
 
-	/**
-	 * 접속로그를 기록한다.
-	 *
-	 * @param LoginLog
-	 * @return
-	 * @throws Exception
-	 */
-	public void logInsertLoginLog(LoginLog loginLog) throws Exception{
-		insert("LoginLogDAO.logInsertLoginLog", loginLog);
+	@Resource(name = "loginLogMapper")
+	private LoginLogMapper loginLogMapper;
+
+	public void logInsertLoginLog(LoginLog loginLog) throws Exception {
+		loginLogMapper.logInsertLoginLog(loginLog);
 	}
 
-	/**
-	 * 접속로그를 조회한다.
-	 *
-	 * @param loginLog
-	 * @return loginLog
-	 * @throws Exception
-	 */
-	public LoginLog selectLoginLog(LoginLog loginLog) throws Exception{
-
-		return (LoginLog) selectOne("LoginLogDAO.selectLoginLog", loginLog);
+	public LoginLog selectLoginLog(LoginLog loginLog) throws Exception {
+		return loginLogMapper.selectLoginLog(loginLog);
 	}
 
-	/**
-	 * 접속로그를 목록을 조회한다.
-	 *
-	 * @param loginLog
-	 * @return
-	 * @throws Exception
-	 */
-	public List<?> selectLoginLogInf(LoginLog loginLog) throws Exception{
-		return selectList("LoginLogDAO.selectLoginLogInf", loginLog);
+	public List<?> selectLoginLogInf(LoginLog loginLog) throws Exception {
+		return loginLogMapper.selectLoginLogInf(loginLog);
 	}
 
-	/**
-	 * 접속로그 목록의 숫자를 조회한다.
-	 * @param loginLog
-	 * @return
-	 * @throws Exception
-	 */
-	public int selectLoginLogInfCnt(LoginLog loginLog) throws Exception{
-
-		return (Integer)selectOne("LoginLogDAO.selectLoginLogInfCnt", loginLog);
+	public int selectLoginLogInfCnt(LoginLog loginLog) throws Exception {
+		return loginLogMapper.selectLoginLogInfCnt(loginLog);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/log/clg/service/impl/LoginLogMapper.java
+++ b/src/main/java/egovframework/let/sym/log/clg/service/impl/LoginLogMapper.java
@@ -1,0 +1,38 @@
+package egovframework.let.sym.log.clg.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.log.clg.service.LoginLog;
+
+/**
+ * 시스템 로그 관리를 위한 Mapper 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.03.11
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.11  이삼섭          최초 생성
+ *   2011.07.01  이기하          패키지 분리(sym.log -> sym.log.clg)
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface LoginLogMapper {
+
+	void logInsertLoginLog(LoginLog loginLog) throws Exception;
+
+	LoginLog selectLoginLog(LoginLog loginLog) throws Exception;
+
+	List<?> selectLoginLogInf(LoginLog loginLog) throws Exception;
+
+	int selectLoginLogInfCnt(LoginLog loginLog) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/log/lgm/service/impl/SysLogDAO.java
+++ b/src/main/java/egovframework/let/sym/log/lgm/service/impl/SysLogDAO.java
@@ -2,10 +2,10 @@ package egovframework.let.sym.log.lgm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.sym.log.lgm.service.SysLog;
+import jakarta.annotation.Resource;
 
 /**
  * 로그관리(시스템)를 위한 데이터 접근 클래스
@@ -26,63 +26,30 @@ import egovframework.let.sym.log.lgm.service.SysLog;
  * </pre>
  */
 @Repository("SysLogDAO")
-public class SysLogDAO extends EgovAbstractMapper {
+public class SysLogDAO {
 
-	/**
-	 * 시스템 로그정보를 생성한다.
-	 *
-	 * @param SysLog
-	 * @return
-	 * @throws Exception
-	 */
-	public void logInsertSysLog(SysLog sysLog) throws Exception{
-		insert("SysLogDAO.logInsertSysLog", sysLog);
+	@Resource(name = "sysLogMapper")
+	private SysLogMapper sysLogMapper;
+
+	public void logInsertSysLog(SysLog sysLog) throws Exception {
+		sysLogMapper.logInsertSysLog(sysLog);
 	}
 
-	/**
-	 * 시스템 로그정보를 요약한다.
-	 *
-	 * @param
-	 * @return
-	 * @throws Exception
-	 */
-	public void logInsertSysLogSummary() throws Exception{
-		insert("SysLogDAO.logInsertSysLogSummary", null);
-		delete("SysLogDAO.logDeleteSysLogSummary", null);
+	public void logInsertSysLogSummary() throws Exception {
+		sysLogMapper.logInsertSysLogSummary();
+		sysLogMapper.logDeleteSysLogSummary();
 	}
 
-	/**
-	 * 시스템 로그정보를 조회한다.
-	 *
-	 * @param sysLog
-	 * @return sysLog
-	 * @throws Exception
-	 */
-	public SysLog selectSysLog(SysLog sysLog) throws Exception{
-
-		return (SysLog) selectOne("SysLogDAO.selectSysLog", sysLog);
+	public SysLog selectSysLog(SysLog sysLog) throws Exception {
+		return sysLogMapper.selectSysLog(sysLog);
 	}
 
-	/**
-	 * 시스템 로그정보 목록을 조회한다.
-	 *
-	 * @param sysLog
-	 * @return
-	 * @throws Exception
-	 */
-	public List<?> selectSysLogInf(SysLog sysLog) throws Exception{
-		return selectList("SysLogDAO.selectSysLogInf", sysLog);
+	public List<?> selectSysLogInf(SysLog sysLog) throws Exception {
+		return sysLogMapper.selectSysLogInf(sysLog);
 	}
 
-	/**
-	 * 시스템 로그정보 목록의 숫자를 조회한다.
-	 * @param sysLog
-	 * @return
-	 * @throws Exception
-	 */
-	public int selectSysLogInfCnt(SysLog sysLog) throws Exception{
-
-		return (Integer)selectOne("SysLogDAO.selectSysLogInfCnt", sysLog);
+	public int selectSysLogInfCnt(SysLog sysLog) throws Exception {
+		return sysLogMapper.selectSysLogInfCnt(sysLog);
 	}
 
 }

--- a/src/main/java/egovframework/let/sym/log/lgm/service/impl/SysLogMapper.java
+++ b/src/main/java/egovframework/let/sym/log/lgm/service/impl/SysLogMapper.java
@@ -1,0 +1,42 @@
+package egovframework.let.sym.log.lgm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.sym.log.lgm.service.SysLog;
+
+/**
+ * 로그관리(시스템)를 위한 Mapper 인터페이스
+ * @author 공통서비스개발팀 이삼섭
+ * @since 2009.03.11
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.11  이삼섭          최초 생성
+ *   2011.07.01  이기하          패키지 분리(sym.log -> sym.log.lgm)
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface SysLogMapper {
+
+	void logInsertSysLog(SysLog sysLog) throws Exception;
+
+	void logInsertSysLogSummary() throws Exception;
+
+	void logDeleteSysLogSummary() throws Exception;
+
+	SysLog selectSysLog(SysLog sysLog) throws Exception;
+
+	List<?> selectSysLogInf(SysLog sysLog) throws Exception;
+
+	int selectSysLogInfCnt(SysLog sysLog) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/sym/mnu/mcm/service/impl/MenuCreateManageDAO.java
+++ b/src/main/java/egovframework/let/sym/mnu/mcm/service/impl/MenuCreateManageDAO.java
@@ -2,14 +2,15 @@ package egovframework.let.sym.mnu.mcm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.let.sym.mnu.mcm.service.MenuCreatVO;
+import egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper;
+import jakarta.annotation.Resource;
 
 /**
- * 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다. *
+ * 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다.
  * @author 공통컴포넌트 개발팀 서준식
  * @since 2011.06.30
  * @version 1.0
@@ -20,106 +21,50 @@ import egovframework.let.sym.mnu.mcm.service.MenuCreatVO;
  *
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
- *   2011.06.30  서 준 식   최초 생성(MenuManageDAO 클래스로 부터 분리
- *   					   메소드들을 MenuManageDAO 클래스에서 분리해옮)
+ *   2011.06.30  서 준 식   최초 생성
  *   2011.08.31  JJY       경량환경 템플릿 커스터마이징버전 생성
  * </pre>
  */
-
 @Repository("menuCreateManageDAO")
-public class MenuCreateManageDAO extends EgovAbstractMapper{
+public class MenuCreateManageDAO {
 
+	@Resource(name = "menuManageMapper")
+	private MenuManageMapper menuManageMapper;
 
-
-	/**
-	 * ID 존재여부를 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectUsrByPk(ComDefaultVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectUsrByPk", vo);
+	public int selectUsrByPk(ComDefaultVO vo) throws Exception {
+		return menuManageMapper.selectUsrByPk(vo);
 	}
 
-	/**
-	 * ID에 대한 권한코드를 조회
-	 * @param vo MenuCreatVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public MenuCreatVO selectAuthorByUsr(ComDefaultVO vo) throws Exception{
-		return (MenuCreatVO)selectOne("menuManageDAO.selectAuthorByUsr", vo);
+	public MenuCreatVO selectAuthorByUsr(ComDefaultVO vo) throws Exception {
+		return menuManageMapper.selectAuthorByUsr(vo);
 	}
 
-	/**
-	 * 메뉴생성관리 내역을 조회
-	 * @param vo ComDefaultVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMenuCreatManagList(ComDefaultVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMenuCreatManageList_D", vo);
+	public List<?> selectMenuCreatManagList(ComDefaultVO vo) throws Exception {
+		return menuManageMapper.selectMenuCreatManageList_D(vo);
 	}
 
-	/**
-	 * 메뉴생성관리 총건수를 조회한다.
-	 * @param vo ComDefaultVO
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectMenuCreatManagTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectMenuCreatManageTotCnt_S", vo);
-    }
-
-    /*********** 메뉴 생성 관리 ***************/
-	/**
-	 * 메뉴생성 내역을 조회
-	 * @param vo MenuCreatVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMenuCreatList(MenuCreatVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMenuCreatList_D", vo);
+	public int selectMenuCreatManagTotCnt(ComDefaultVO vo) {
+		return menuManageMapper.selectMenuCreatManageTotCnt_S(vo);
 	}
 
-	/**
-	 * 메뉴생성내역 등록
-	 * @param vo MenuCreatVO
-	 * @exception Exception
-	 */
-	public void insertMenuCreat(MenuCreatVO vo){
-		insert("menuManageDAO.insertMenuCreat_S", vo);
+	public List<?> selectMenuCreatList(MenuCreatVO vo) throws Exception {
+		return menuManageMapper.selectMenuCreatList_D(vo);
 	}
 
-
-	/**
-	 * 메뉴생성내역 존재여부 조회한다.
-	 * @param vo MenuCreatVO
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectMenuCreatCnt(MenuCreatVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectMenuCreatCnt_S", vo);
-    }
-
-
-	/**
-	 * 메뉴생성내역 수정
-	 * @param vo MenuCreatVO
-	 * @exception Exception
-	 */
-	public void updateMenuCreat(MenuCreatVO vo){
-		update("menuManageDAO.updateMenuCreat_S", vo);
+	public void insertMenuCreat(MenuCreatVO vo) {
+		menuManageMapper.insertMenuCreat_S(vo);
 	}
 
-	/**
-	 * 메뉴생성내역 삭제
-	 * @param vo MenuCreatVO
-	 * @exception Exception
-	 */
-	public void deleteMenuCreat(MenuCreatVO vo){
-		delete("menuManageDAO.deleteMenuCreat_S", vo);
+	public int selectMenuCreatCnt(MenuCreatVO vo) {
+		return menuManageMapper.selectMenuCreatCnt_S(vo);
 	}
 
+	public void updateMenuCreat(MenuCreatVO vo) {
+		menuManageMapper.updateMenuCreat_S(vo);
+	}
+
+	public void deleteMenuCreat(MenuCreatVO vo) {
+		menuManageMapper.deleteMenuCreat_S(vo);
+	}
 
 }

--- a/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageDAO.java
+++ b/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageDAO.java
@@ -2,11 +2,12 @@ package egovframework.let.sym.mnu.mpm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.let.sym.mnu.mpm.service.MenuManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 메뉴관리, 메뉴생성, 사이트맵 생성에 대한 DAO 클래스를 정의한다.
  * @author 개발환경 개발팀 이용
@@ -20,189 +21,83 @@ import egovframework.let.sym.mnu.mpm.service.MenuManageVO;
  *   수정일      수정자           수정내용
  *  -------    --------    ---------------------------
  *   2009.03.20  이  용          최초 생성
- *   2011.07.01  서준식			자기 메뉴 정보를 상위메뉴 정보로 참조하는 메뉴정보가 있는지 조회하는
- *   							selectUpperMenuNoByPk() 메서드 추가
+ *   2011.07.01  서준식          selectUpperMenuNoByPk() 메서드 추가
  *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
  *
  * </pre>
  */
-
 @Repository("menuManageDAO")
-public class MenuManageDAO extends EgovAbstractMapper{
+public class MenuManageDAO {
 
-	/**
-	 * 메뉴목록을 조회
-	 * @param vo ComDefaultVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMenuManageList(ComDefaultVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMenuManageList_D", vo);
+	@Resource(name = "menuManageMapper")
+	private MenuManageMapper menuManageMapper;
+
+	public List<?> selectMenuManageList(ComDefaultVO vo) throws Exception {
+		return menuManageMapper.selectMenuManageList_D(vo);
 	}
 
-    /**
-	 * 메뉴목록관리 총건수를 조회한다.
-	 * @param vo ComDefaultVO
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectMenuManageListTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("menuManageDAO.selectMenuManageListTotCnt_S", vo);
-    }
-
-	/**
-	 * 메뉴목록관리 기본정보를 조회
-	 * @param vo ComDefaultVO
-	 * @return MenuManageVO
-	 * @exception Exception
-	 */
-	public MenuManageVO selectMenuManage(ComDefaultVO vo)throws Exception{
-		return (MenuManageVO)selectOne("menuManageDAO.selectMenuManage_D", vo);
+	public int selectMenuManageListTotCnt(ComDefaultVO vo) {
+		return menuManageMapper.selectMenuManageListTotCnt_S(vo);
 	}
 
-	/**
-	 * 메뉴목록 기본정보를 등록
-	 * @param vo MenuManageVO
-	 * @exception Exception
-	 */
-	public void insertMenuManage(MenuManageVO vo){
-		insert("menuManageDAO.insertMenuManage_S", vo);
+	public MenuManageVO selectMenuManage(ComDefaultVO vo) throws Exception {
+		return menuManageMapper.selectMenuManage_D(vo);
 	}
 
-	/**
-	 * 메뉴목록 기본정보를 수정
-	 * @param vo MenuManageVO
-	 * @exception Exception
-	 */
-	public void updateMenuManage(MenuManageVO vo){
-		update("menuManageDAO.updateMenuManage_S", vo);
+	public void insertMenuManage(MenuManageVO vo) {
+		menuManageMapper.insertMenuManage_S(vo);
 	}
 
-	/**
-	 * 메뉴목록 기본정보를 삭제
-	 * @param vo MenuManageVO
-	 * @exception Exception
-	 */
-	public void deleteMenuManage(MenuManageVO vo){
-		delete("menuManageDAO.deleteMenuManage_S", vo);
+	public void updateMenuManage(MenuManageVO vo) {
+		menuManageMapper.updateMenuManage_S(vo);
 	}
 
-	/**
-	 * 메뉴 전체목록을 조회
-	 * @return list
-	 * @exception Exception
-	 */
-	public List<?> selectMenuList() throws Exception{
-		ComDefaultVO vo  = new ComDefaultVO();
-		return selectList("menuManageDAO.selectMenuListT_D", vo);
+	public void deleteMenuManage(MenuManageVO vo) {
+		menuManageMapper.deleteMenuManage_S(vo);
 	}
 
-
-	/**
-	 * 메뉴번호 존재여부를 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectMenuNoByPk(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectMenuNoByPk", vo);
+	public List<?> selectMenuList() throws Exception {
+		ComDefaultVO vo = new ComDefaultVO();
+		return menuManageMapper.selectMenuListT_D(vo);
 	}
 
-
-
-	/**
-	 * 메뉴번호를 상위메뉴로 참조하고 있는 메뉴 존재여부를 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectUpperMenuNoByPk(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectUpperMenuNoByPk", vo);
+	public int selectMenuNoByPk(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMenuNoByPk(vo);
 	}
 
+	public int selectUpperMenuNoByPk(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectUpperMenuNoByPk(vo);
+	}
 
-
-
-
-
-
-
-
-
-
-
-
-
-	/**
-	 * 메뉴정보 전체삭제 초기화
-	 * @return boolean
-	 * @exception Exception
-	 */
-	public boolean deleteAllMenuList(){
+	public boolean deleteAllMenuList() {
 		MenuManageVO vo = new MenuManageVO();
-		insert("menuManageDAO.deleteAllMenuList", vo);
+		menuManageMapper.deleteAllMenuList(vo);
 		return true;
 	}
 
-    /**
-	 * 메뉴정보 존재여부 조회한다.
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectMenuListTotCnt() {
-    	MenuManageVO vo = new MenuManageVO();
-        return (Integer)selectOne("menuManageDAO.selectMenuListTotCnt", vo);
-    }
-
-
-	/*### 메뉴관련 프로세스 ###*/
-	/**
-	 * MainMenu Head Menu 조회
-	 * @param vo MenuManageVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMainMenuHead(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuHead", vo);
+	public int selectMenuListTotCnt() {
+		MenuManageVO vo = new MenuManageVO();
+		return menuManageMapper.selectMenuListTotCnt(vo);
 	}
 
-	/**
-	 * MainMenu Left Menu 조회
-	 * @param vo MenuManageVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception{
-		return selectList("menuManageDAO.selectMainMenuLeft", vo);
+	public List<?> selectMainMenuHead(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMainMenuHead(vo);
 	}
 
-	/**
-	 * MainMenu Head MenuURL 조회
-	 * @param vo MenuManageVO
-	 * @return  String
-	 * @exception Exception
-	 */
-	public String selectLastMenuURL(MenuManageVO vo) throws Exception{
-		return (String)selectOne("menuManageDAO.selectLastMenuURL", vo);
+	public List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectMainMenuLeft(vo);
 	}
 
-	/**
-	 * MainMenu Left Menu 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectLastMenuNo(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectLastMenuNo", vo);
+	public String selectLastMenuURL(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectLastMenuURL(vo);
 	}
 
-	/**
-	 * MainMenu Left Menu 조회
-	 * @param vo MenuManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectLastMenuNoCnt(MenuManageVO vo) throws Exception{
-		return (Integer)selectOne("menuManageDAO.selectLastMenuNoCnt", vo);
+	public int selectLastMenuNo(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectLastMenuNo(vo);
 	}
+
+	public int selectLastMenuNoCnt(MenuManageVO vo) throws Exception {
+		return menuManageMapper.selectLastMenuNoCnt(vo);
+	}
+
 }

--- a/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageMapper.java
+++ b/src/main/java/egovframework/let/sym/mnu/mpm/service/impl/MenuManageMapper.java
@@ -1,0 +1,87 @@
+package egovframework.let.sym.mnu.mpm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.sym.mnu.mcm.service.MenuCreatVO;
+import egovframework.let.sym.mnu.mpm.service.MenuManageVO;
+
+/**
+ * 메뉴관리, 메뉴생성에 대한 Mapper 인터페이스를 정의한다.
+ * @author 개발환경 개발팀 이용
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  이  용          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface MenuManageMapper {
+
+	/* ===== EgovMenuManage_SQL (메뉴관리) ===== */
+
+	List<?> selectMenuManageList_D(ComDefaultVO vo) throws Exception;
+
+	int selectMenuManageListTotCnt_S(ComDefaultVO vo);
+
+	MenuManageVO selectMenuManage_D(ComDefaultVO vo) throws Exception;
+
+	void insertMenuManage_S(MenuManageVO vo);
+
+	void updateMenuManage_S(MenuManageVO vo);
+
+	void deleteMenuManage_S(MenuManageVO vo);
+
+	int selectMenuNoByPk(MenuManageVO vo) throws Exception;
+
+	int selectUpperMenuNoByPk(MenuManageVO vo) throws Exception;
+
+	List<?> selectMenuListT_D(ComDefaultVO vo) throws Exception;
+
+	void deleteAllMenuList(MenuManageVO vo);
+
+	int selectMenuListTotCnt(MenuManageVO vo);
+
+	/* ===== EgovMainMenu_SQL (메인메뉴) ===== */
+
+	List<?> selectMainMenuHead(MenuManageVO vo) throws Exception;
+
+	List<?> selectMainMenuLeft(MenuManageVO vo) throws Exception;
+
+	String selectLastMenuURL(MenuManageVO vo) throws Exception;
+
+	int selectLastMenuNo(MenuManageVO vo) throws Exception;
+
+	int selectLastMenuNoCnt(MenuManageVO vo) throws Exception;
+
+	/* ===== EgovMenuCreat_SQL (메뉴생성) ===== */
+
+	int selectUsrByPk(ComDefaultVO vo) throws Exception;
+
+	MenuCreatVO selectAuthorByUsr(ComDefaultVO vo) throws Exception;
+
+	List<?> selectMenuCreatManageList_D(ComDefaultVO vo) throws Exception;
+
+	int selectMenuCreatManageTotCnt_S(ComDefaultVO vo);
+
+	List<?> selectMenuCreatList_D(MenuCreatVO vo) throws Exception;
+
+	void insertMenuCreat_S(MenuCreatVO vo);
+
+	int selectMenuCreatCnt_S(MenuCreatVO vo);
+
+	void updateMenuCreat_S(MenuCreatVO vo);
+
+	void deleteMenuCreat_S(MenuCreatVO vo);
+
+}

--- a/src/main/java/egovframework/let/sym/prm/service/impl/ProgrmManageDAO.java
+++ b/src/main/java/egovframework/let/sym/prm/service/impl/ProgrmManageDAO.java
@@ -2,12 +2,13 @@ package egovframework.let.sym.prm.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.ComDefaultVO;
 import egovframework.let.sym.prm.service.ProgrmManageDtlVO;
 import egovframework.let.sym.prm.service.ProgrmManageVO;
+import jakarta.annotation.Resource;
+
 /**
  * 프로그램 목록관리및 프로그램변경관리에 대한 DAO 클래스를 정의한다.
  * @author 개발환경 개발팀 이용
@@ -25,216 +26,99 @@ import egovframework.let.sym.prm.service.ProgrmManageVO;
  *
  * </pre>
  */
-
 @Repository("progrmManageDAO")
-public class ProgrmManageDAO extends EgovAbstractMapper {
+public class ProgrmManageDAO {
 
-	/**
-	 * 프로그램 목록을 조회
-	 * @param vo ComDefaultVO
-	 * @return List
-	 * @exception Exception
-	 */
+	@Resource(name = "progrmManageMapper")
+	private ProgrmManageMapper progrmManageMapper;
 
-	public List<?> selectProgrmList(ComDefaultVO vo) throws Exception{
-		return selectList("progrmManageDAO.selectProgrmList_D", vo);
+	public List<?> selectProgrmList(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmList_D(vo);
 	}
 
-    /**
-	 * 프로그램목록 총건수를 조회한다.
-	 * @param vo ComDefaultVO
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectProgrmListTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("progrmManageDAO.selectProgrmListTotCnt_S", vo);
-    }
-
-	/**
-	 * 프로그램 기본정보를 조회
-	 * @param vo ComDefaultVO
-	 * @return ProgrmManageVO
-	 * @exception Exception
-	 */
-	public ProgrmManageVO selectProgrm(ComDefaultVO vo)throws Exception{
-		return (ProgrmManageVO)selectOne("progrmManageDAO.selectProgrm_D", vo);
+	public int selectProgrmListTotCnt(ComDefaultVO vo) {
+		return progrmManageMapper.selectProgrmListTotCnt_S(vo);
 	}
 
-	/**
-	 * 프로그램 기본정보 및 URL을 등록
-	 * @param vo ProgrmManageVO
-	 * @exception Exception
-	 */
-	public void insertProgrm(ProgrmManageVO vo){
-		insert("progrmManageDAO.insertProgrm_S", vo);
+	public ProgrmManageVO selectProgrm(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectProgrm_D(vo);
 	}
 
-	/**
-	 * 프로그램 기본정보 및 URL을 수정
-	 * @param vo ProgrmManageVO
-	 * @exception Exception
-	 */
-	public void updateProgrm(ProgrmManageVO vo){
-		update("progrmManageDAO.updateProgrm_S", vo);
+	public void insertProgrm(ProgrmManageVO vo) {
+		progrmManageMapper.insertProgrm_S(vo);
 	}
 
-	/**
-	 * 프로그램 기본정보 및 URL을 삭제
-	 * @param vo ProgrmManageVO
-	 * @exception Exception
-	 */
-	public void deleteProgrm(ProgrmManageVO vo){
-		delete("progrmManageDAO.deleteProgrm_S", vo);
+	public void updateProgrm(ProgrmManageVO vo) {
+		progrmManageMapper.updateProgrm_S(vo);
 	}
 
-	/**
-	 * 프로그램 파일 존재여부를 조회
-	 * @param vo ProgrmManageVO
-	 * @return int
-	 * @exception Exception
-	 */
-	public int selectProgrmNMTotCnt(ComDefaultVO vo) throws Exception{
-		return (Integer)selectOne("progrmManageDAO.selectProgrmNMTotCnt", vo);
+	public void deleteProgrm(ProgrmManageVO vo) {
+		progrmManageMapper.deleteProgrm_S(vo);
 	}
 
-
-	/**
-	 * 프로그램변경요청 목록을 조회
-	 * @param vo ComDefaultVO
-	 * @return List
-	 * @exception Exception
-	 */
-
-	public List<?> selectProgrmChangeRequstList(ComDefaultVO vo) throws Exception{
-		return selectList("progrmManageDAO.selectProgrmChangeRequstList_D", vo);
+	public int selectProgrmNMTotCnt(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmNMTotCnt(vo);
 	}
 
-    /**
-	 * 프로그램변경요청 총건수를 조회한다.
-	 * @param vo ComDefaultVO
-	 * @return  int
-	 * @exception Exception
-	 */
-    public int selectProgrmChangeRequstListTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("progrmManageDAO.selectProgrmChangeRequstListTotCnt_S", vo);
-    }
-
-	/**
-	 * 프로그램변경요청 정보를 조회
-	 * @param vo ProgrmManageDtlVO
-	 * @return ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public ProgrmManageDtlVO selectProgrmChangeRequst(ProgrmManageDtlVO vo)throws Exception{
-		return (ProgrmManageDtlVO)selectOne("progrmManageDAO.selectProgrmChangeRequst_D", vo);
+	public List<?> selectProgrmChangeRequstList(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmChangeRequstList_D(vo);
 	}
 
-	/**
-	 * 프로그램변경요청을 등록
-	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public void insertProgrmChangeRequst(ProgrmManageDtlVO vo){
-		insert("progrmManageDAO.insertProgrmChangeRequst_S", vo);
+	public int selectProgrmChangeRequstListTotCnt(ComDefaultVO vo) {
+		return progrmManageMapper.selectProgrmChangeRequstListTotCnt_S(vo);
 	}
 
-	/**
-	 * 프로그램변경요청을 수정
-	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public void updateProgrmChangeRequst(ProgrmManageDtlVO vo){
-		update("progrmManageDAO.updateProgrmChangeRequst_S", vo);
+	public ProgrmManageDtlVO selectProgrmChangeRequst(ProgrmManageDtlVO vo) throws Exception {
+		return progrmManageMapper.selectProgrmChangeRequst_D(vo);
 	}
 
-	/**
-	 * 프로그램변경요청을 삭제
-	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public void deleteProgrmChangeRequst(ProgrmManageDtlVO vo){
-		delete("progrmManageDAO.deleteProgrmChangeRequst_S", vo);
+	public void insertProgrmChangeRequst(ProgrmManageDtlVO vo) {
+		progrmManageMapper.insertProgrmChangeRequst_S(vo);
 	}
 
-	/**
-	 * 프로그램변경요청 요청번호MAX 정보를 조회
-	 * @param vo ProgrmManageDtlVO
-	 * @return ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public ProgrmManageDtlVO selectProgrmChangeRequstNo(ProgrmManageDtlVO vo){
-		return (ProgrmManageDtlVO)selectOne("progrmManageDAO.selectProgrmChangeRequstNo_D", vo);
+	public void updateProgrmChangeRequst(ProgrmManageDtlVO vo) {
+		progrmManageMapper.updateProgrmChangeRequst_S(vo);
 	}
 
-	/**
-	 * 프로그램변경요청 목록을 조회
-	 * @param vo ComDefaultVO
-	 * @return List
-	 * @exception Exception
-	 */
-	public List<?> selectChangeRequstProcessList(ComDefaultVO vo) throws Exception{
-		return selectList("progrmManageDAO.selectChangeRequstProcessList_D", vo);
+	public void deleteProgrmChangeRequst(ProgrmManageDtlVO vo) {
+		progrmManageMapper.deleteProgrmChangeRequst_S(vo);
 	}
 
-    /**
-	 * 프로그램변경요청 총건수를 조회한다.
-	 * @param vo ComDefaultVO
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectChangeRequstListProcessTotCnt(ComDefaultVO vo) {
-        return (Integer)selectOne("progrmManageDAO.selectChangeRequstProcessListTotCnt_S", vo);
-    }
-
-	/**
-	 * 프로그램변경요청 처리 수정
-	 * @param vo ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public void updateProgrmChangeRequstProcess(ProgrmManageDtlVO vo){
-		update("progrmManageDAO.updateProgrmChangeRequstProcess_S", vo);
+	public ProgrmManageDtlVO selectProgrmChangeRequstNo(ProgrmManageDtlVO vo) {
+		return progrmManageMapper.selectProgrmChangeRequstNo_D(vo);
 	}
 
+	public List<?> selectChangeRequstProcessList(ComDefaultVO vo) throws Exception {
+		return progrmManageMapper.selectChangeRequstProcessList_D(vo);
+	}
 
-	/**
-	 * 프로그램목록 전체삭제 초기화
-	 * @return boolean
-	 * @exception Exception
-	 */
-	public boolean deleteAllProgrm(){
+	public int selectChangeRequstListProcessTotCnt(ComDefaultVO vo) {
+		return progrmManageMapper.selectChangeRequstProcessListTotCnt_S(vo);
+	}
+
+	public void updateProgrmChangeRequstProcess(ProgrmManageDtlVO vo) {
+		progrmManageMapper.updateProgrmChangeRequstProcess_S(vo);
+	}
+
+	public boolean deleteAllProgrm() {
 		ProgrmManageVO vo = new ProgrmManageVO();
-		update("progrmManageDAO.deleteAllProgrm", vo);
+		progrmManageMapper.deleteAllProgrm(vo);
 		return true;
 	}
 
-	/**
-	 * 프로그램변경내역 전체삭제 초기화
-	 * @return boolean
-	 * @exception Exception
-	 */
-	public boolean deleteAllProgrmDtls(){
+	public boolean deleteAllProgrmDtls() {
 		ProgrmManageDtlVO vo = new ProgrmManageDtlVO();
-		update("progrmManageDAO.deleteAllProgrmDtls", vo);
+		progrmManageMapper.deleteAllProgrmDtls(vo);
 		return true;
 	}
 
-    /**
-	 * 프로그램목록 데이타 존재여부 조회한다.
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectProgrmListTotCnt() {
-    	ProgrmManageVO vo = new ProgrmManageVO();
-        return (Integer)selectOne("progrmManageDAO.selectProgrmListTotCnt", vo);
-    }
-
-	/**
-	 * 프로그램변경요청자 Email 정보를 조회
-	 * @param vo ProgrmManageDtlVO
-	 * @return ProgrmManageDtlVO
-	 * @exception Exception
-	 */
-	public ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo){
-		return (ProgrmManageDtlVO)selectOne("progrmManageDAO.selectRqesterEmail", vo);
+	public int selectProgrmListTotCnt() {
+		ProgrmManageVO vo = new ProgrmManageVO();
+		return progrmManageMapper.selectProgrmListTotCnt(vo);
 	}
+
+	public ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo) {
+		return progrmManageMapper.selectRqesterEmail(vo);
+	}
+
 }

--- a/src/main/java/egovframework/let/sym/prm/service/impl/ProgrmManageMapper.java
+++ b/src/main/java/egovframework/let/sym/prm/service/impl/ProgrmManageMapper.java
@@ -1,0 +1,73 @@
+package egovframework.let.sym.prm.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.ComDefaultVO;
+import egovframework.let.sym.prm.service.ProgrmManageDtlVO;
+import egovframework.let.sym.prm.service.ProgrmManageVO;
+
+/**
+ * 프로그램 목록관리 및 프로그램변경관리에 대한 Mapper 인터페이스를 정의한다.
+ * @author 개발환경 개발팀 이용
+ * @since 2009.06.01
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.03.20  이  용          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface ProgrmManageMapper {
+
+	List<?> selectProgrmList_D(ComDefaultVO vo) throws Exception;
+
+	int selectProgrmListTotCnt_S(ComDefaultVO vo);
+
+	int selectProgrmNMTotCnt(ComDefaultVO vo) throws Exception;
+
+	ProgrmManageVO selectProgrm_D(ComDefaultVO vo) throws Exception;
+
+	void insertProgrm_S(ProgrmManageVO vo);
+
+	void updateProgrm_S(ProgrmManageVO vo);
+
+	void deleteProgrm_S(ProgrmManageVO vo);
+
+	void deleteAllProgrm(ProgrmManageVO vo);
+
+	int selectProgrmListTotCnt(ProgrmManageVO vo);
+
+	List<?> selectProgrmChangeRequstList_D(ComDefaultVO vo) throws Exception;
+
+	int selectProgrmChangeRequstListTotCnt_S(ComDefaultVO vo);
+
+	ProgrmManageDtlVO selectProgrmChangeRequstNo_D(ProgrmManageDtlVO vo);
+
+	ProgrmManageDtlVO selectProgrmChangeRequst_D(ProgrmManageDtlVO vo) throws Exception;
+
+	void insertProgrmChangeRequst_S(ProgrmManageDtlVO vo);
+
+	void updateProgrmChangeRequst_S(ProgrmManageDtlVO vo);
+
+	void deleteProgrmChangeRequst_S(ProgrmManageDtlVO vo);
+
+	void updateProgrmChangeRequstProcess_S(ProgrmManageDtlVO vo);
+
+	List<?> selectChangeRequstProcessList_D(ComDefaultVO vo) throws Exception;
+
+	int selectChangeRequstProcessListTotCnt_S(ComDefaultVO vo);
+
+	void deleteAllProgrmDtls(ProgrmManageDtlVO vo);
+
+	ProgrmManageDtlVO selectRqesterEmail(ProgrmManageDtlVO vo);
+
+}

--- a/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyDAO.java
+++ b/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyDAO.java
@@ -2,15 +2,14 @@ package egovframework.let.uat.uap.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uat.uap.service.LoginPolicy;
 import egovframework.let.uat.uap.service.LoginPolicyVO;
+import jakarta.annotation.Resource;
+
 /**
  * 로그인정책에 대한 DAO 클래스를 정의한다.
- * 로그인정책에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
- * 로그인정책의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 공통서비스개발팀 lee.m.j
  * @since 2009.08.03
  * @version 1.0
@@ -27,65 +26,37 @@ import egovframework.let.uat.uap.service.LoginPolicyVO;
  * </pre>
  */
 @Repository("loginPolicyDAO")
-public class LoginPolicyDAO extends EgovAbstractMapper {
+public class LoginPolicyDAO {
 
-	/**
-	 * 로그인정책 목록을 조회한다.
-	 * @param loginPolicyVO - 로그인정책 VO
-	 * @return List - 로그인정책 목록
-	 */
+	@Resource(name = "loginPolicyMapper")
+	private LoginPolicyMapper loginPolicyMapper;
+
 	public List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) throws Exception {
-		return selectList("loginPolicyDAO.selectLoginPolicyList", loginPolicyVO);
+		return loginPolicyMapper.selectLoginPolicyList(loginPolicyVO);
 	}
 
-	/**
-	 * 로그인정책 목록 수를 조회한다.
-	 * @param loginPolicyVO - 로그인정책 VO
-	 * @return int
-	 */
 	public int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) throws Exception {
-		return (Integer)selectOne("loginPolicyDAO.selectLoginPolicyListTotCnt", loginPolicyVO);
+		return loginPolicyMapper.selectLoginPolicyListTotCnt(loginPolicyVO);
 	}
 
-	/**
-	 * 로그인정책 목록의 상세정보를 조회한다.
-	 * @param loginPolicyVO - 로그인정책 VO
-	 * @return LoginPolicyVO - 로그인정책 VO
-	 */
 	public LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO) {
-		return (LoginPolicyVO)selectOne("loginPolicyDAO.selectLoginPolicy", loginPolicyVO);
+		return loginPolicyMapper.selectLoginPolicy(loginPolicyVO);
 	}
 
-	/**
-	 * 로그인정책 정보를 신규로 등록한다.
-	 * @param loginPolicy - 로그인정책 model
-	 */
 	public void insertLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-        insert("loginPolicyDAO.insertLoginPolicy", loginPolicy);
+		loginPolicyMapper.insertLoginPolicy(loginPolicy);
 	}
 
-	/**
-	 * 기 등록된 로그인정책 정보를 수정한다.
-	 * @param loginPolicy - 로그인정책 model
-	 */
 	public void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-		update("loginPolicyDAO.updateLoginPolicy", loginPolicy);
+		loginPolicyMapper.updateLoginPolicy(loginPolicy);
 	}
 
-	/**
-	 * 기 등록된 로그인정책 정보를 삭제한다.
-	 * @param loginPolicy - 로그인정책 model
-	 */
 	public void deleteLoginPolicy(LoginPolicy loginPolicy) throws Exception {
-		delete("loginPolicyDAO.deleteLoginPolicy", loginPolicy);
+		loginPolicyMapper.deleteLoginPolicy(loginPolicy);
 	}
 
-	/**
-	 * 로그인정책에 대한 현재 반영되어 있는 결과를 조회한다.
-	 * @param loginPolicyVO - 로그인정책 VO
-	 * @return LoginPolicyVO - 로그인정책 VO
-	 */
 	public LoginPolicyVO selectLoginPolicyResult(LoginPolicyVO loginPolicyVO) throws Exception {
 		return null;
 	}
+
 }

--- a/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyMapper.java
+++ b/src/main/java/egovframework/let/uat/uap/service/impl/LoginPolicyMapper.java
@@ -1,0 +1,42 @@
+package egovframework.let.uat.uap.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uat.uap.service.LoginPolicy;
+import egovframework.let.uat.uap.service.LoginPolicyVO;
+
+/**
+ * 로그인정책에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스개발팀 lee.m.j
+ * @since 2009.08.03
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.03  lee.m.j        최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface LoginPolicyMapper {
+
+	List<LoginPolicyVO> selectLoginPolicyList(LoginPolicyVO loginPolicyVO) throws Exception;
+
+	int selectLoginPolicyListTotCnt(LoginPolicyVO loginPolicyVO) throws Exception;
+
+	LoginPolicyVO selectLoginPolicy(LoginPolicyVO loginPolicyVO);
+
+	void insertLoginPolicy(LoginPolicy loginPolicy) throws Exception;
+
+	void updateLoginPolicy(LoginPolicy loginPolicy) throws Exception;
+
+	void deleteLoginPolicy(LoginPolicy loginPolicy) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginDAO.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginDAO.java
@@ -1,8 +1,10 @@
 package egovframework.let.uat.uia.service.impl;
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
+
 import org.springframework.stereotype.Repository;
 
 import egovframework.com.cmm.LoginVO;
+import jakarta.annotation.Resource;
+
 /**
  * 일반 로그인을 처리하는 DAO 클래스
  * @author 공통서비스 개발팀 박지욱
@@ -21,46 +23,25 @@ import egovframework.com.cmm.LoginVO;
  *  </pre>
  */
 @Repository("loginDAO")
-public class LoginDAO extends EgovAbstractMapper {
+public class LoginDAO {
 
-	/**
-	 * 일반 로그인을 처리한다
-	 * @param vo LoginVO
-	 * @return LoginVO
-	 * @exception Exception
-	 */
-    public LoginVO actionLogin(LoginVO vo) throws Exception {
-    	return (LoginVO)selectOne("loginDAO.actionLogin", vo);
-    }
+	@Resource(name = "loginMapper")
+	private LoginMapper loginMapper;
 
-    /**
-	 * 아이디를 찾는다.
-	 * @param vo LoginVO
-	 * @return LoginVO
-	 * @exception Exception
-	 */
-    public LoginVO searchId(LoginVO vo) throws Exception {
+	public LoginVO actionLogin(LoginVO vo) throws Exception {
+		return loginMapper.actionLogin(vo);
+	}
 
-    	return (LoginVO)selectOne("loginDAO.searchId", vo);
-    }
+	public LoginVO searchId(LoginVO vo) throws Exception {
+		return loginMapper.searchId(vo);
+	}
 
-    /**
-	 * 비밀번호를 찾는다.
-	 * @param vo LoginVO
-	 * @return LoginVO
-	 * @exception Exception
-	 */
-    public LoginVO searchPassword(LoginVO vo) throws Exception {
+	public LoginVO searchPassword(LoginVO vo) throws Exception {
+		return loginMapper.searchPassword(vo);
+	}
 
-    	return (LoginVO)selectOne("loginDAO.searchPassword", vo);
-    }
+	public void updatePassword(LoginVO vo) throws Exception {
+		loginMapper.updatePassword(vo);
+	}
 
-    /**
-	 * 변경된 비밀번호를 저장한다.
-	 * @param vo LoginVO
-	 * @exception Exception
-	 */
-    public void updatePassword(LoginVO vo) throws Exception {
-    	update("loginDAO.updatePassword", vo);
-    }
 }

--- a/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
+++ b/src/main/java/egovframework/let/uat/uia/service/impl/LoginMapper.java
@@ -1,0 +1,35 @@
+package egovframework.let.uat.uia.service.impl;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.com.cmm.LoginVO;
+
+/**
+ * 일반 로그인을 처리하는 Mapper 인터페이스
+ * @author 공통서비스 개발팀 박지욱
+ * @since 2009.03.06
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자          수정내용
+ *  -------    --------    ---------------------------
+ *  2009.03.06  박지욱          최초 생성
+ *  2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface LoginMapper {
+
+	LoginVO actionLogin(LoginVO vo) throws Exception;
+
+	LoginVO searchId(LoginVO vo) throws Exception;
+
+	LoginVO searchPassword(LoginVO vo) throws Exception;
+
+	void updatePassword(LoginVO vo) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/ion/uas/service/impl/UserAbsnceDAO.java
+++ b/src/main/java/egovframework/let/uss/ion/uas/service/impl/UserAbsnceDAO.java
@@ -2,15 +2,14 @@ package egovframework.let.uss.ion.uas.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.ion.uas.service.UserAbsnce;
 import egovframework.let.uss.ion.uas.service.UserAbsnceVO;
+import jakarta.annotation.Resource;
+
 /**
  * 사용자부재에 대한 DAO 클래스를 정의한다.
- * 사용자부재에 대한 등록, 수정, 삭제, 조회, 반영확인 기능을 제공한다.
- * 사용자부재의 조회기능은 목록조회, 상세조회로 구분된다.
  * @author 공통서비스개발팀 lee.m.j
  * @since 2009.08.03
  * @version 1.0
@@ -27,66 +26,37 @@ import egovframework.let.uss.ion.uas.service.UserAbsnceVO;
  * </pre>
  */
 @Repository("userAbsnceDAO")
-public class UserAbsnceDAO extends EgovAbstractMapper {
+public class UserAbsnceDAO {
 
-	/**
-	 * 사용자부재정보를 관리하기 위해 등록된 사용자부재 목록을 조회한다.
-	 * @param userAbsnceVO - 사용자부재 VO
-	 * @return List - 사용자부재 목록
-	 */
+	@Resource(name = "userAbsnceMapper")
+	private UserAbsnceMapper userAbsnceMapper;
+
 	public List<UserAbsnceVO> selectUserAbsnceList(UserAbsnceVO userAbsnceVO) throws Exception {
-		return selectList("userAbsnceDAO.selectUserAbsnceList", userAbsnceVO);
+		return userAbsnceMapper.selectUserAbsnceList(userAbsnceVO);
 	}
 
-    /**
-	 * 사용자부재목록 총 갯수를 조회한다.
-	 * @param mainImageVO - 사용자부재 VO
-	 * @return int
-	 * @exception Exception
-	 */
-    public int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO) throws Exception {
-        return (Integer)selectOne("userAbsnceDAO.selectUserAbsnceListTotCnt", userAbsnceVO);
-    }
+	public int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO) throws Exception {
+		return userAbsnceMapper.selectUserAbsnceListTotCnt(userAbsnceVO);
+	}
 
-	/**
-	 * 등록된 사용자부재 상세정보를 조회한다.
-	 * @param userAbsnceVO - 사용자부재 VO
-	 * @return UserAbsnceVO - 사용자부재 VO
-	 */
 	public UserAbsnceVO selectUserAbsnce(UserAbsnceVO userAbsnceVO) throws Exception {
-		return (UserAbsnceVO) selectOne("userAbsnceDAO.selectUserAbsnce", userAbsnceVO);
+		return userAbsnceMapper.selectUserAbsnce(userAbsnceVO);
 	}
 
-	/**
-	 * 사용자부재정보를 신규로 등록한다.
-	 * @param userAbsnce - 사용자부재 model
-	 */
 	public void insertUserAbsnce(UserAbsnce userAbsnce) throws Exception {
-		insert("userAbsnceDAO.insertUserAbsnce", userAbsnce);
+		userAbsnceMapper.insertUserAbsnce(userAbsnce);
 	}
 
-	/**
-	 * 기 등록된 사용자부재정보를 수정한다.
-	 * @param userAbsnce - 사용자부재 model
-	 */
 	public void updateUserAbsnce(UserAbsnce userAbsnce) throws Exception {
-		update("userAbsnceDAO.updateUserAbsnce", userAbsnce);
+		userAbsnceMapper.updateUserAbsnce(userAbsnce);
 	}
 
-	/**
-	 * 기 등록된 사용자부재정보를 삭제한다.
-	 * @param userAbsnce - 사용자부재 model
-	 */
 	public void deleteUserAbsnce(UserAbsnce userAbsnce) throws Exception {
-		delete("userAbsnceDAO.deleteUserAbsnce", userAbsnce);
+		userAbsnceMapper.deleteUserAbsnce(userAbsnce);
 	}
 
-	/**
-	 * 사용자부재정보가 특정화면에 반영된 결과를 조회한다.
-	 * @param userAbsnceVO - 사용자부재 VO
-	 * @return UserAbsnceVO - 사용자부재 VO
-	 */
 	public UserAbsnceVO selectUserAbsnceResult(UserAbsnceVO userAbsnceVO) throws Exception {
 		return null;
 	}
+
 }

--- a/src/main/java/egovframework/let/uss/ion/uas/service/impl/UserAbsnceMapper.java
+++ b/src/main/java/egovframework/let/uss/ion/uas/service/impl/UserAbsnceMapper.java
@@ -1,0 +1,42 @@
+package egovframework.let.uss.ion.uas.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.ion.uas.service.UserAbsnce;
+import egovframework.let.uss.ion.uas.service.UserAbsnceVO;
+
+/**
+ * 사용자부재에 대한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스개발팀 lee.m.j
+ * @since 2009.08.03
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.08.03  lee.m.j        최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface UserAbsnceMapper {
+
+	List<UserAbsnceVO> selectUserAbsnceList(UserAbsnceVO userAbsnceVO) throws Exception;
+
+	int selectUserAbsnceListTotCnt(UserAbsnceVO userAbsnceVO) throws Exception;
+
+	UserAbsnceVO selectUserAbsnce(UserAbsnceVO userAbsnceVO) throws Exception;
+
+	void insertUserAbsnce(UserAbsnce userAbsnce) throws Exception;
+
+	void updateUserAbsnce(UserAbsnce userAbsnce) throws Exception;
+
+	void deleteUserAbsnce(UserAbsnce userAbsnce) throws Exception;
+
+}

--- a/src/main/java/egovframework/let/uss/umt/service/impl/UserManageDAO.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/UserManageDAO.java
@@ -2,11 +2,11 @@ package egovframework.let.uss.umt.service.impl;
 
 import java.util.List;
 
-import org.egovframe.rte.psl.dataaccess.EgovAbstractMapper;
 import org.springframework.stereotype.Repository;
 
 import egovframework.let.uss.umt.service.UserDefaultVO;
 import egovframework.let.uss.umt.service.UserManageVO;
+import jakarta.annotation.Resource;
 
 /**
  * 사용자관리에 관한 데이터 접근 클래스를 정의한다.
@@ -26,94 +26,49 @@ import egovframework.let.uss.umt.service.UserManageVO;
  * </pre>
  */
 @Repository("userManageDAO")
-public class UserManageDAO extends EgovAbstractMapper{
+public class UserManageDAO {
 
-    /**
-     * 입력한 사용자아이디의 중복여부를 체크하여 사용가능여부를 확인
-     * @param checkId 중복체크대상 아이디
-     * @return int 사용가능여부(아이디 사용회수 )
-     */
-    public int checkIdDplct(String checkId){
-        return (Integer)selectOne("userManageDAO.checkIdDplct_S", checkId);
-    }
+	@Resource(name = "userManageMapper")
+	private UserManageMapper userManageMapper;
 
-    /**
-     * 화면에 조회된 사용자의 정보를 데이터베이스에서 삭제
-     * @param delId 삭제대상 업무사용자 아이디
-     */
-    public void deleteUser(String delId){
-        delete("userManageDAO.deleteUser_S", delId);
-    }
+	public int checkIdDplct(String checkId) {
+		return userManageMapper.checkIdDplct_S(checkId);
+	}
 
+	public void deleteUser(String delId) {
+		userManageMapper.deleteUser_S(delId);
+	}
 
-    /**
-     * 사용자의 기본정보를 화면에서 입력하여 항목의 정합성을 체크하고 데이터베이스에 저장
-     * @param userManageVO 업무사용자 등록정보
-     * @return String result 등록결과
-     */
-    public void insertUser(UserManageVO userManageVO){
-        insert("userManageDAO.insertUser_S", userManageVO);
-    }
+	public void insertUser(UserManageVO userManageVO) {
+		userManageMapper.insertUser_S(userManageVO);
+	}
 
-    /**
-     * 기 등록된 사용자 중 검색조건에 맞는 사용자들의 정보를 데이터베이스에서 읽어와 화면에 출력
-     * @param uniqId 상세조회대상 업무사용자아이디
-     * @return UserManageVO 업무사용자  상세정보
-     */
-    public UserManageVO selectUser(String uniqId){
-        return (UserManageVO) selectOne("userManageDAO.selectUser_S", uniqId);
-    }
+	public UserManageVO selectUser(String uniqId) {
+		return userManageMapper.selectUser_S(uniqId);
+	}
 
-    /**
-     * 기 등록된 특정 사용자의 정보를 데이터베이스에서 읽어와 화면에 출력
-     * @param userSearchVO 검색조건
-     * @return List 업무사용자 목록정보
-     */
-	public List<?> selectUserList(UserDefaultVO userSearchVO){
-        return selectList("userManageDAO.selectUserList_S", userSearchVO);
-    }
+	public List<?> selectUserList(UserDefaultVO userSearchVO) {
+		return userManageMapper.selectUserList_S(userSearchVO);
+	}
 
-    /**
-     * 사용자총 갯수를 조회한다.
-     * @param userSearchVO 검색조건
-     * @return int 업무사용자 총갯수
-     */
-    public int selectUserListTotCnt(UserDefaultVO userSearchVO) {
-        return (Integer)selectOne("userManageDAO.selectUserListTotCnt_S", userSearchVO);
-    }
+	public int selectUserListTotCnt(UserDefaultVO userSearchVO) {
+		return userManageMapper.selectUserListTotCnt_S(userSearchVO);
+	}
 
-    /**
-     * 화면에 조회된 사용자의 기본정보를 수정하여 항목의 정합성을 체크하고 수정된 데이터를 데이터베이스에 반영
-     * @param userManageVO 업무사용자 수정정보
-     */
-    public void updateUser(UserManageVO userManageVO){
-        update("userManageDAO.updateUser_S",userManageVO);
-    }
+	public void updateUser(UserManageVO userManageVO) {
+		userManageMapper.updateUser_S(userManageVO);
+	}
 
-    /**
-     * 사용자정보 수정시 히스토리 정보를 추가
-     * @param userManageVO 업무사용자 히스토리 정보
-     * @return String 히스토리 등록결과
-     */
-    public void insertUserHistory(UserManageVO userManageVO){
-    	insert("userManageDAO.insertUserHistory_S", userManageVO);
-    }
+	public void insertUserHistory(UserManageVO userManageVO) {
+		userManageMapper.insertUserHistory_S(userManageVO);
+	}
 
-    /**
-     * 업무사용자 암호수정
-     * @param passVO 업무사용자수정정보(비밀번호)
-     */
-    public void updatePassword(UserManageVO passVO) {
-        update("userManageDAO.updatePassword_S", passVO);
-    }
+	public void updatePassword(UserManageVO passVO) {
+		userManageMapper.updatePassword_S(passVO);
+	}
 
-    /**
-     * 업무사용자가 비밀번호를 기억하지 못할 때 비밀번호를 찾을 수 있도록 함
-     * @param userManageVO 업무 사용자암호 조회조건정보
-     * @return UserManageVO 업무사용자 암호정보
-     */
-    public UserManageVO selectPassword(UserManageVO userManageVO){
-    	return (UserManageVO) selectOne("userManageDAO.selectPassword_S", userManageVO);
-    }
+	public UserManageVO selectPassword(UserManageVO userManageVO) {
+		return userManageMapper.selectPassword_S(userManageVO);
+	}
 
 }

--- a/src/main/java/egovframework/let/uss/umt/service/impl/UserManageMapper.java
+++ b/src/main/java/egovframework/let/uss/umt/service/impl/UserManageMapper.java
@@ -1,0 +1,50 @@
+package egovframework.let.uss.umt.service.impl;
+
+import java.util.List;
+
+import org.egovframe.rte.psl.dataaccess.mapper.EgovMapper;
+
+import egovframework.let.uss.umt.service.UserDefaultVO;
+import egovframework.let.uss.umt.service.UserManageVO;
+
+/**
+ * 사용자관리에 관한 Mapper 인터페이스를 정의한다.
+ * @author 공통서비스 개발팀 조재영
+ * @since 2009.04.10
+ * @version 1.0
+ * @see
+ *
+ * <pre>
+ * << 개정이력(Modification Information) >>
+ *
+ *   수정일      수정자           수정내용
+ *  -------    --------    ---------------------------
+ *   2009.04.10  조재영          최초 생성
+ *   2011.08.31  JJY            경량환경 템플릿 커스터마이징버전 생성
+ *
+ * </pre>
+ */
+@EgovMapper
+public interface UserManageMapper {
+
+	int checkIdDplct_S(String checkId);
+
+	void deleteUser_S(String delId);
+
+	void insertUser_S(UserManageVO userManageVO);
+
+	UserManageVO selectUser_S(String uniqId);
+
+	List<?> selectUserList_S(UserDefaultVO userSearchVO);
+
+	int selectUserListTotCnt_S(UserDefaultVO userSearchVO);
+
+	void updateUser_S(UserManageVO userManageVO);
+
+	void insertUserHistory_S(UserManageVO userManageVO);
+
+	void updatePassword_S(UserManageVO passVO);
+
+	UserManageVO selectPassword_S(UserManageVO userManageVO);
+
+}

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cca/EgovCmmnCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cca.service.impl.CmmnCodeManageMapper">
 
 
 	<select id="selectCmmnCodeList" parameterType="egovframework.let.sym.ccm.cca.service.CmmnCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/ccc/EgovCmmnClCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnClCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.ccc.service.impl.CmmnClCodeManageMapper">
 
 
 	<select id="selectCmmnClCodeList" parameterType="egovframework.let.sym.ccm.ccc.service.CmmnClCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeManageMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeManageMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeManageMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeManageMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeManageMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/cde/EgovCmmnDetailCodeManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="CmmnDetailCodeManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.cde.service.impl.CmmnDetailCodeManageMapper">
 
 
 	<select id="selectCmmnDetailCodeList" parameterType="egovframework.let.sym.ccm.cde.service.CmmnDetailCodeVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/ccm/zip/EgovZipManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="ZipManageDAO">
+<mapper namespace="egovframework.let.sym.ccm.zip.service.impl.ZipManageMapper">
 
 
 	<select id="selectZipList" parameterType="egovframework.let.sym.ccm.zip.service.ZipVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/clg/EgovLoginLog_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="LoginLogDAO">
+<mapper namespace="egovframework.let.sym.log.clg.service.impl.LoginLogMapper">
 
 	<!-- 로그인로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
     <!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
     <!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
     <!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/log/lgm/EgovSysLog_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="SysLogDAO">
+<mapper namespace="egovframework.let.sym.log.lgm.service.impl.SysLogMapper">
 
 	<!-- 시스템로그 VO -->
 

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mcm/EgovMenuCreat_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMenuCreatManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMainMenu_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 	
 	<select id="selectMainMenuHead" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="menuManageDAO">
+<mapper namespace="egovframework.let.sym.mnu.mpm.service.impl.MenuManageMapper">
 
 
 	<select id="selectMenuManageList_D" parameterType="comDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램 변경요청  --> 

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램 변경요청  --> 

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램 변경요청  --> 

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램 변경요청  --> 

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램 변경요청  --> 

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램 변경요청  --> 

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
  
     <!-- 프로그램목록 관리 -->

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램목록 관리 -->

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램목록 관리 -->

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램목록 관리 -->

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램목록 관리 -->

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="progrmManageDAO">
+<mapper namespace="egovframework.let.sym.prm.service.impl.ProgrmManageMapper">
 
 
     <!-- 프로그램목록 관리 -->

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
 	<resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
 	<resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uap/EgovLoginPolicy_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginPolicyDAO">
+<mapper namespace="egovframework.let.uat.uap.service.impl.LoginPolicyMapper">
 
     <resultMap id="loginPolicy" type="egovframework.let.uat.uap.service.LoginPolicyVO">
         <result property="emplyrId" column="USER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->
@@ -27,7 +27,7 @@
 	</resultMap>
 	
 	<!-- 일반 로그인 -->
-	<select id="loginDAO.actionLogin" resultMap="login">
+	<select id="actionLogin" resultMap="login">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -82,7 +82,7 @@
 	</select>
 	
 	<!-- 인증서 로그인 -->
-	<select id="loginDAO.actionCrtfctLogin" resultMap="login">
+	<select id="actionCrtfctLogin" resultMap="login">
 		
 		SELECT emplyr_id AS id
 		     , user_nm AS name
@@ -98,7 +98,7 @@
 	</select>
 	
 	<!-- 아이디 찾기 -->
-	<select id="loginDAO.searchId" resultMap="id">
+	<select id="searchId" resultMap="id">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -132,7 +132,7 @@
 	</select>
 	
 	<!-- 비밀번호 찾기 -->
-	<select id="loginDAO.searchPassword" resultMap="password">
+	<select id="searchPassword" resultMap="password">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -175,7 +175,7 @@
 	</select>
 	
 	<!-- 변경된 비밀번호를 저장 -->
-	<update id="loginDAO.updatePassword">
+	<update id="updatePassword">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->
@@ -27,7 +27,7 @@
 	</resultMap>
 	
 	<!-- 일반 로그인 -->
-	<select id="loginDAO.actionLogin" resultMap="login">
+	<select id="actionLogin" resultMap="login">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -82,7 +82,7 @@
 	</select>
 	
 	<!-- 인증서 로그인 -->
-	<select id="loginDAO.actionCrtfctLogin" resultMap="login">
+	<select id="actionCrtfctLogin" resultMap="login">
 		
 		SELECT emplyr_id AS id
 		     , USER_NM AS name
@@ -98,7 +98,7 @@
 	</select>
 	
 	<!-- 아이디 찾기 -->
-	<select id="loginDAO.searchId" resultMap="id">
+	<select id="searchId" resultMap="id">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -132,7 +132,7 @@
 	</select>
 	
 	<!-- 비밀번호 찾기 -->
-	<select id="loginDAO.searchPassword" resultMap="password">
+	<select id="searchPassword" resultMap="password">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -175,7 +175,7 @@
 	</select>
 	
 	<!-- 변경된 비밀번호를 저장 -->
-	<update id="loginDAO.updatePassword">
+	<update id="updatePassword">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->
@@ -27,7 +27,7 @@
 	</resultMap>
 	-->
 	<!-- 일반 로그인 -->
-	<select id="loginDAO.actionLogin" resultMap="login">
+	<select id="actionLogin" resultMap="login">
 		<if test="userSe == &quot;USR&quot;">
 			
             SELECT EMPLYR_ID AS id
@@ -47,7 +47,7 @@
 	</select>
 	
 	<!-- 인증서 로그인
-	<select id="loginDAO.actionCrtfctLogin" resultMap="login">
+	<select id="actionCrtfctLogin" resultMap="login">
 		<![CDATA[
 		SELECT emplyr_id AS id
 		     , USER_NM AS name
@@ -63,7 +63,7 @@
 	</select>
 	 -->
 	<!-- 아이디 찾기
-	<select id="loginDAO.searchId" resultMap="id">
+	<select id="searchId" resultMap="id">
 		<isEqual property="userSe" compareValue="GNR">
 			<![CDATA[
 			SELECT mber_id AS id
@@ -94,7 +94,7 @@
 	</select>
 	 -->
 	<!-- 비밀번호 찾기 
-	<select id="loginDAO.searchPassword" resultMap="password">
+	<select id="searchPassword" resultMap="password">
 		<isEqual property="userSe" compareValue="GNR">
 			<![CDATA[
 			SELECT password AS password
@@ -134,7 +134,7 @@
 	</select>
 	-->
 	<!-- 변경된 비밀번호를 저장 
-	<update id="loginDAO.updatePassword">
+	<update id="updatePassword">
 		<isEqual property="userSe" compareValue="GNR">
 			<![CDATA[
 			UPDATE LETTNGNRLMBER

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->
@@ -27,7 +27,7 @@
 	</resultMap>
 	
 	<!-- 일반 로그인 -->
-	<select id="loginDAO.actionLogin" resultMap="login">
+	<select id="actionLogin" resultMap="login">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -82,7 +82,7 @@
 	</select>
 	
 	<!-- 인증서 로그인 -->
-	<select id="loginDAO.actionCrtfctLogin" resultMap="login">
+	<select id="actionCrtfctLogin" resultMap="login">
 		
 		SELECT emplyr_id AS id
 		     , USER_NM AS name
@@ -98,7 +98,7 @@
 	</select>
 	
 	<!-- 아이디 찾기 -->
-	<select id="loginDAO.searchId" resultMap="id">
+	<select id="searchId" resultMap="id">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -132,7 +132,7 @@
 	</select>
 	
 	<!-- 비밀번호 찾기 -->
-	<select id="loginDAO.searchPassword" resultMap="password">
+	<select id="searchPassword" resultMap="password">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -175,7 +175,7 @@
 	</select>
 	
 	<!-- 변경된 비밀번호를 저장 -->
-	<update id="loginDAO.updatePassword">
+	<update id="updatePassword">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->
@@ -27,7 +27,7 @@
 	</resultMap>
 	-->
 	<!-- 일반 로그인 -->
-	<select id="loginDAO.actionLogin" resultMap="login">
+	<select id="actionLogin" resultMap="login">
 		<if test="userSe == &quot;USR&quot;">
 			
             SELECT EMPLYR_ID AS "id"
@@ -47,7 +47,7 @@
 	</select>
 	
 	<!-- 인증서 로그인
-	<select id="loginDAO.actionCrtfctLogin" resultMap="login">
+	<select id="actionCrtfctLogin" resultMap="login">
 		<![CDATA[
 		SELECT emplyr_id AS "id"
 		     , USER_NM AS "name"
@@ -63,7 +63,7 @@
 	</select>
 	 -->
 	<!-- 아이디 찾기
-	<select id="loginDAO.searchId" resultMap="id">
+	<select id="searchId" resultMap="id">
 		<isEqual property="userSe" compareValue="GNR">
 			<![CDATA[
 			SELECT mber_id AS "id"
@@ -94,7 +94,7 @@
 	</select>
 	 -->
 	<!-- 비밀번호 찾기 
-	<select id="loginDAO.searchPassword" resultMap="password">
+	<select id="searchPassword" resultMap="password">
 		<isEqual property="userSe" compareValue="GNR">
 			<![CDATA[
 			SELECT password AS "password"
@@ -134,7 +134,7 @@
 	</select>
 	-->
 	<!-- 변경된 비밀번호를 저장 
-	<update id="loginDAO.updatePassword">
+	<update id="updatePassword">
 		<isEqual property="userSe" compareValue="GNR">
 			<![CDATA[
 			UPDATE LETTNGNRLMBER

--- a/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uat/uia/EgovLoginUsr_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="loginDAO">
+<mapper namespace="egovframework.let.uat.uia.service.impl.LoginMapper">
 
 
 	<!-- 로그인 처리를 위한 resultMap -->
@@ -27,7 +27,7 @@
 	</resultMap>
 	
 	<!-- 일반 로그인 -->
-	<select id="loginDAO.actionLogin" resultMap="login">
+	<select id="actionLogin" resultMap="login">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -82,7 +82,7 @@
 	</select>
 	
 	<!-- 인증서 로그인 -->
-	<select id="loginDAO.actionCrtfctLogin" resultMap="login">
+	<select id="actionCrtfctLogin" resultMap="login">
 		
 		SELECT emplyr_id AS id
 		     , user_nm AS name
@@ -98,7 +98,7 @@
 	</select>
 	
 	<!-- 아이디 찾기 -->
-	<select id="loginDAO.searchId" resultMap="id">
+	<select id="searchId" resultMap="id">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -132,7 +132,7 @@
 	</select>
 	
 	<!-- 비밀번호 찾기 -->
-	<select id="loginDAO.searchPassword" resultMap="password">
+	<select id="searchPassword" resultMap="password">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			
@@ -175,7 +175,7 @@
 	</select>
 	
 	<!-- 변경된 비밀번호를 저장 -->
-	<update id="loginDAO.updatePassword">
+	<update id="updatePassword">
 		<!-- 일반회원 -->
 		<if test="userSe == &quot;GNR&quot;">
 			

--- a/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.let.uss.ion.uas.service.impl.UserAbsnceMapper">
 
 
     <resultMap id="userAbsnce" type="egovframework.let.uss.ion.uas.service.UserAbsnceVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.let.uss.ion.uas.service.impl.UserAbsnceMapper">
 
 
     <resultMap id="userAbsnce" type="egovframework.let.uss.ion.uas.service.UserAbsnceVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.let.uss.ion.uas.service.impl.UserAbsnceMapper">
 
 
     <resultMap id="userAbsnce" type="egovframework.let.uss.ion.uas.service.UserAbsnceVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.let.uss.ion.uas.service.impl.UserAbsnceMapper">
 
 
     <resultMap id="userAbsnce" type="egovframework.let.uss.ion.uas.service.UserAbsnceVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.let.uss.ion.uas.service.impl.UserAbsnceMapper">
 
 
     <resultMap id="userAbsnce" type="egovframework.let.uss.ion.uas.service.UserAbsnceVO">

--- a/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/ion/uas/EgovUserAbsnce_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userAbsnceDAO">
+<mapper namespace="egovframework.let.uss.ion.uas.service.impl.UserAbsnceMapper">
 
 
     <resultMap id="userAbsnce" type="egovframework.let.uss.ion.uas.service.UserAbsnceVO">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_altibase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.UserManageMapper">
 
 
     <select id="selectUserList_S" parameterType="egovframework.let.uss.umt.service.UserDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_cubrid.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_cubrid.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.UserManageMapper">
 
 
     <select id="selectUserList_S" parameterType="egovframework.let.uss.umt.service.UserDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_mysql.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_mysql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.UserManageMapper">
 
 
     <select id="selectUserList_S" parameterType="egovframework.let.uss.umt.service.UserDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_oracle.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_oracle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.UserManageMapper">
 
 
     <select id="selectUserList_S" parameterType="egovframework.let.uss.umt.service.UserDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_postgres.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_postgres.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.UserManageMapper">
 
 
     <select id="selectUserList_S" parameterType="egovframework.let.uss.umt.service.UserDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/uss/umt/EgovUserManage_SQL_tibero.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="userManageDAO">
+<mapper namespace="egovframework.let.uss.umt.service.impl.UserManageMapper">
 
 
     <select id="selectUserList_S" parameterType="egovframework.let.uss.umt.service.UserDefaultVO" resultType="egovMap">

--- a/src/main/resources/egovframework/spring/com/context-mapper.xml
+++ b/src/main/resources/egovframework/spring/com/context-mapper.xml
@@ -22,5 +22,12 @@
 	</bean>
 	
 	<alias name="sqlSession" alias="egov.sqlSession" />
-	
+
+	<!-- @EgovMapper 인터페이스 스캔 -->
+	<bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
+		<property name="basePackage" value="egovframework.let" />
+		<property name="annotationClass" value="org.egovframe.rte.psl.dataaccess.mapper.EgovMapper" />
+		<property name="sqlSessionFactoryBeanName" value="sqlSession" />
+	</bean>
+
 </beans>


### PR DESCRIPTION
## 변경 사유
기존 XML namespace 기반 DAO를 eGovFrame 5.0 `@EgovMapper` 인터페이스 방식으로 전환합니다.

## 변경 내용
- 대상: sym/ccm·log·mnu·prm, uat, uss/ion/uas, uss/umt 12개 DAO
- Mapper 인터페이스(`@EgovMapper`) 신규 추가 + DAO 위임 구조 전환
- XML namespace를 mapper FQN으로 변경
- context-mapper.xml MapperScannerConfigurer(basePackage=egovframework.let, annotationClass=EgovMapper) 등록

## 영향 범위
- 해당 모듈만 영향, 서비스 호출 시그니처 변경 없음
- `mvn compile` BUILD SUCCESS 확인

## 참고
- 동일 리포 다른 @EgovMapper PR과 context-mapper.xml의 MapperScannerConfigurer가 한 줄 중복될 수 있으며, 선행 PR 머지 후 rebase로 정리 가능

## 체크리스트
- [x] 단일 주제만 다룸
- [x] 빌드 검증 완료
- [x] 기존 동작 호환
