### PR TITLE
refactor(datasource): 데이터베이스 커넥션 풀을 HikariCP로 전환

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 		<protobuf.java.version>3.25.5</protobuf.java.version>
 		<xmlbeans.version>5.3.0</xmlbeans.version>
 		<parsson.version>1.1.7</parsson.version>
+		<hikaricp.version>6.3.3</hikaricp.version>
 	</properties>
 
 	<dependencies>
@@ -174,8 +175,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-dbcp2</artifactId>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>${hikaricp.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/egovframework/spring/com/context-datasource.xml
+++ b/src/main/resources/egovframework/spring/com/context-datasource.xml
@@ -15,43 +15,48 @@
     <alias name="dataSource-${Globals.DbType}" alias="egov.dataSource" />
     
     <!-- mysql -->
-    <bean id="dataSource-mysql" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-mysql" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
     <!-- Oracle -->
-    <bean id="dataSource-oracle" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-oracle" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
     <!-- Altibase -->
-    <bean id="dataSource-altibase" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-altibase" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
 
     <!-- Tibero -->
-    <bean id="dataSource-tibero" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-tibero" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
     <!-- cubrid -->
-    <bean id="dataSource-cubrid" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
+    <bean id="dataSource-cubrid" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="${Globals.DriverClassName}"/>
-        <property name="url" value="${Globals.Url}" />
+        <property name="jdbcUrl" value="${Globals.Url}" />
         <property name="username" value="${Globals.UserName}"/>
         <property name="password" value="${Globals.Password}"/>
+        <property name="maximumPoolSize" value="10"/>
     </bean>
     
 </beans>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 개요

데이터베이스 커넥션 풀 구현체를 Apache Commons DBCP2에서 HikariCP로 전환합니다.

### 주요 변경 사항

- `commons-dbcp2` 의존성을 제거했습니다.
- HikariCP 6.3.3 의존성을 추가했습니다.
- 데이터소스 구현체를 `BasicDataSource`에서 `HikariDataSource`로 변경했습니다.
- HikariCP 설정에 맞게 연결 URL 속성을 `url`에서 `jdbcUrl`로 변경했습니다.
- 최대 커넥션 풀 크기(`maximumPoolSize`)를 10으로 설정했습니다.
- MySQL, Oracle, Altibase, Tibero, Cubrid 데이터소스 설정에 동일하게 적용했습니다.

### 검증

- JDK 17.0.17 및 Maven 3.9.9 환경에서 검증했습니다.
- `mvn -DskipTests verify` 빌드가 성공했습니다.
- 컴파일 및 WAR 패키징이 정상적으로 완료되었습니다.
- 의존성 트리에서 `com.zaxxer:HikariCP:6.3.3` 적용을 확인했습니다.
- 생성된 WAR에 `HikariCP-6.3.3.jar`가 포함된 것을 확인했습니다.
- 프로젝트 소스에서 DBCP2 관련 참조가 제거된 것을 확인했습니다.

### 참고

테스트는 프로젝트 설정 및 검증 명령의 `skipTests` 옵션에 따라 실행하지 않았습니다.
기존 JavaDoc 경고는 이번 변경과 무관하며 빌드 결과에는 영향을 주지 않습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
