### PR TITLE
fix(cop/bbs): 대상별 게시판 마스터 수정에서 입력값 검증이 실행되지 않는 문제 수정

### DIFF
--- a/src/main/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageController.java
+++ b/src/main/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageController.java
@@ -461,7 +461,7 @@ public class EgovBBSAttributeManageController {
 	 */
 	@RequestMapping(value = "/cop/bbs/UpdateBBSMasterInfByTrget.do", method = RequestMethod.POST)
 	public String updateBBSMasterInfByTrget(@ModelAttribute("searchVO") BoardMasterVO boardMasterVO,
-		@ModelAttribute("boardMaster") BoardMaster boardMaster,
+		@Valid @ModelAttribute("boardMaster") BoardMaster boardMaster,
 		BindingResult bindingResult, ModelMap model) throws Exception {
 
 		checkAuthority(boardMasterVO); // server-side 권한 확인

--- a/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerValidationTest.java
+++ b/src/test/java/egovframework/let/cop/bbs/web/EgovBBSAttributeManageControllerValidationTest.java
@@ -1,0 +1,59 @@
+package egovframework.let.cop.bbs.web;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.validation.BindingResult;
+
+import jakarta.validation.Valid;
+
+/**
+ * BindingResult를 선언한 핸들러는 바로 앞 파라미터에 {@code @Valid}가 있어야 한다.
+ *
+ * {@code @Valid}가 없으면 Spring이 검증기를 호출하지 않아 BindingResult가 항상 비고,
+ * bindingResult.hasErrors() 분기가 실행되지 않는다.
+ *
+ * @author 최완택
+ * @since 2026-08-30
+ */
+@DisplayName("게시판 속성 관리 컨트롤러")
+class EgovBBSAttributeManageControllerValidationTest {
+
+	@Test
+	@DisplayName("BindingResult를 받는 핸들러는 검증 대상 파라미터에 @Valid를 선언한다")
+	void handlersWithBindingResultDeclareValid() {
+		List<String> missing = new ArrayList<>();
+
+		for (Method method : EgovBBSAttributeManageController.class.getDeclaredMethods()) {
+			Parameter[] parameters = method.getParameters();
+
+			for (int i = 1; i < parameters.length; i++) {
+				if (!BindingResult.class.isAssignableFrom(parameters[i].getType())) {
+					continue;
+				}
+				if (!hasValid(parameters[i - 1])) {
+					missing.add(method.getName());
+				}
+			}
+		}
+
+		assertTrue(missing.isEmpty(), "BindingResult 앞 파라미터에 @Valid가 없는 핸들러: " + missing);
+	}
+
+	private boolean hasValid(Parameter parameter) {
+		for (Annotation annotation : parameter.getAnnotations()) {
+			if (annotation instanceof Valid) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovBBSAttributeManageController.updateBBSMasterInfByTrget`은 `BindingResult`를 받아 `bindingResult.hasErrors()`로 분기하지만, 검증 대상 파라미터에 `@Valid`가 없습니다. Spring이 검증기를 호출하지 않으므로 `BindingResult`는 항상 비어 있고 그 분기는 실행되지 않습니다. `BoardMaster`에 선언된 제약도 검사되지 않습니다.

4.3.0까지 이 컨트롤러는 네 개 핸들러 모두에서 검증을 직접 호출했습니다.

```java
// 4.3.0 (7980361) — beanValidator.validate 호출 4곳
beanValidator.validate(boardMaster, bindingResult);
```

5.0.0(`d30957b`)에서 `@Valid`로 바꾸면서 `insertBBSMasterInf`·`updateBBSMasterInf`·`insertBdMstrByTrget` 세 곳만 옮겨졌습니다. 같은 대상별 계열인 `EgovBBSUseInfoManageController`의 `insertBBSUseInfByTrget`·`updateBBSUseInfByTrget`에도 `@Valid`가 붙어 있습니다.

AS-IS / TO-BE

```diff
 	public String updateBBSMasterInfByTrget(@ModelAttribute("searchVO") BoardMasterVO boardMasterVO,
-		@ModelAttribute("boardMaster") BoardMaster boardMaster,
+		@Valid @ModelAttribute("boardMaster") BoardMaster boardMaster,
 		BindingResult bindingResult, ModelMap model) throws Exception {
```

### 범위

이 수정으로 달라지는 것은 검증이 실행되어 오류 분기가 동작한다는 점까지입니다. 그 분기가 반환하는 뷰가 대상별 화면이 아닌 `cop/bbs/EgovBoardMstrUpdt`인 것은 별개 사안이라 이번 범위에서 뺐습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

이 컨트롤러에서 `BindingResult`를 선언한 핸들러가 검증 대상 파라미터에 `@Valid`가 있는지 확인하는 테스트를 추가했습니다.

수정 전

```
[ERROR] EgovBBSAttributeManageControllerValidationTest.handlersWithBindingResultDeclareValid:46
        BindingResult 앞 파라미터에 @Valid가 없는 핸들러: [updateBBSMasterInfByTrget]
        ==> expected: <true> but was: <false>
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 `-DskipTests=false`로는 덮어써지지 않습니다. 그 값을 잠시 해제하고 실행한 결과입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

이 엔드포인트가 사용하는 대상별 화면(`EgovBdMstrUpdtByTrget`)이 저장소에 없어 브라우저로 재현할 경로가 없습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 화면 캡처를 첨부하지 못했습니다.

