### PR TITLE
fix(sym/mnu): 티베로 매퍼에 상위 메뉴번호 조회 쿼리 누락 보완

### DIFF
--- a/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_tibero.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/mnu/mpm/EgovMenuManage_SQL_tibero.xml
@@ -99,6 +99,15 @@
 		 WHERE MENU_NO = #{menuNo}
 		
 	</select>
+	
+	<!-- 상위 메뉴번호 존재여부 조회 -->
+    <select id="selectUpperMenuNoByPk" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="int">
+        
+        SELECT COUNT(MENU_NO) AS totcnt
+          FROM LETTNMENUINFO
+         WHERE UPPER_MENU_NO = #{menuNo}
+        
+    </select>
 
 	<select id="selectMenuListT_D" parameterType="comDefaultVO" resultType="egovMap">
 		 

--- a/src/test/java/egovframework/test/EgovMapperVariantTest.java
+++ b/src/test/java/egovframework/test/EgovMapperVariantTest.java
@@ -1,0 +1,84 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * 같은 매퍼의 데이터베이스별 변종은 같은 쿼리 아이디 집합을 가져야 한다.
+ *
+ * 한 변종에만 쿼리가 빠지면 그 데이터베이스에서만 화면이 실패한다.
+ *
+ * @author 최완택
+ * @since 2026-08-30
+ */
+@DisplayName("매퍼 변종")
+class EgovMapperVariantTest {
+
+	private static final Pattern FILE_NAME = Pattern
+			.compile("(.+)_(mysql|oracle|postgres|cubrid|tibero|altibase|hsql)\\.xml$");
+
+	private static final Pattern STATEMENT_ID = Pattern
+			.compile("<(?:select|insert|update|delete)\\s+id=\"([^\"]+)\"");
+
+	@Test
+	@DisplayName("데이터베이스별 변종이 같은 쿼리 아이디를 선언한다")
+	void mapperVariantsDeclareSameStatementIds() throws IOException {
+		Map<String, Map<String, Set<String>>> groups = new LinkedHashMap<>();
+
+		try (Stream<Path> paths = Files.walk(Paths.get("src/main/resources/egovframework/mapper"))) {
+			for (Path path : paths.filter(Files::isRegularFile).toList()) {
+				Matcher fileName = FILE_NAME.matcher(path.getFileName().toString());
+				if (!fileName.matches()) {
+					continue;
+				}
+				groups.computeIfAbsent(fileName.group(1), key -> new LinkedHashMap<>())
+						.put(fileName.group(2), statementIds(path));
+			}
+		}
+
+		List<String> missing = new ArrayList<>();
+
+		for (Map.Entry<String, Map<String, Set<String>>> group : groups.entrySet()) {
+			Set<String> union = new TreeSet<>();
+			group.getValue().values().forEach(union::addAll);
+
+			for (Map.Entry<String, Set<String>> variant : group.getValue().entrySet()) {
+				Set<String> gap = new TreeSet<>(union);
+				gap.removeAll(variant.getValue());
+				if (!gap.isEmpty()) {
+					missing.add(group.getKey() + "_" + variant.getKey() + ".xml " + gap);
+				}
+			}
+		}
+
+		assertTrue(missing.isEmpty(), "변종에 빠진 쿼리: " + missing);
+	}
+
+	private Set<String> statementIds(Path path) throws IOException {
+		Set<String> ids = new HashSet<>();
+		Matcher matcher = STATEMENT_ID.matcher(Files.readString(path, StandardCharsets.UTF_8));
+		while (matcher.find()) {
+			ids.add(matcher.group(1));
+		}
+		return ids;
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`EgovMenuManage_SQL_tibero.xml`에 `selectUpperMenuNoByPk`가 없습니다. 나머지 여섯 개 변종(mysql·oracle·postgres·cubrid·altibase·hsql)에는 모두 있습니다.

`EgovMenuManageController`는 이 쿼리를 조건 없이 부릅니다.

```java
// EgovMenuManageController.java:166 (등록), :300 (수정)
if (menuManageService.selectUpperMenuNoByPk(menuManageVO) != 0) {
```

`Globals.DbType`이 `tibero`면 메뉴 등록과 수정에서 MyBatis가 해당 구문을 찾지 못합니다.

AS-IS / TO-BE

```diff
+	<!-- 상위 메뉴번호 존재여부 조회 -->
+    <select id="selectUpperMenuNoByPk" parameterType="egovframework.let.sym.mnu.mpm.service.MenuManageVO" resultType="int">
+
+        SELECT COUNT(MENU_NO) AS totcnt
+          FROM LETTNMENUINFO
+         WHERE UPPER_MENU_NO = #{menuNo}
+
+    </select>
```

`EgovMenuManage_SQL_oracle.xml`에서 그대로 가져왔습니다. 이 두 파일은 이 블록을 뺀 나머지가 동일했고 추가 후 완전히 같아집니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

같은 매퍼의 데이터베이스별 변종이 같은 쿼리 아이디를 선언하는지 확인하는 테스트를 추가했습니다.

수정 전

```
[ERROR] EgovMapperVariantTest.mapperVariantsDeclareSameStatementIds
        변종에 빠진 쿼리: [EgovMenuManage_SQL_tibero.xml [selectUpperMenuNoByPk]]
```

수정 후

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 `-DskipTests=false`로는 덮어써지지 않습니다. 그 값을 잠시 해제하고 실행한 결과입니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

티베로 환경이 없어 브라우저로 확인하지 못했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.

