### PR TITLE
fix(jsp): 낡은 네임스페이스를 가리키던 화면 링크 경로 수정

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/cmm/uss/umt/EgovUserPasswordUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/cmm/uss/umt/EgovUserPasswordUpdt.jsp
@@ -98,7 +98,7 @@ function fnUpdate(){
 				<input type="hidden" name="sbscrbSttus" value="<c:out value='${userSearchVO.sbscrbSttus}'/>"/>
 				<input type="hidden" name="pageIndex" value="<c:out value='${userSearchVO.pageIndex}'/>"/>
 				<!-- 우편번호검색 -->
-				<input type="hidden" name="url" value="<c:url value='/sym/ccm/zip/EgovCcmZipSearchPopup.do'/>" />
+				<input type="hidden" name="url" value="<c:url value='/sym/cmm/EgovCcmZipSearchPopup.do'/>" />
 
                                 <h1 class="tit_1">내부시스템관리</h1>
 

--- a/src/main/webapp/WEB-INF/jsp/sec/gmt/EgovGroupManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sec/gmt/EgovGroupManage.jsp
@@ -188,7 +188,7 @@ function press() {
                                 </div>
                                 <!--// Location -->
 
-								<form:form id="listForm" name="listForm" action="<c:url value='/sec/gmt/EgovAuthorList.do'/>" method="get">
+								<form:form id="listForm" name="listForm" action="<c:url value='/sec/ram/EgovAuthorList.do'/>" method="get">
 
                                 <h1 class="tit_1">내부시스템관리</h1>
 

--- a/src/main/webapp/WEB-INF/jsp/sec/ram/EgovAuthorRoleManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sec/ram/EgovAuthorRoleManage.jsp
@@ -133,7 +133,7 @@ function fncSelectAuthorList(){
 
 function fncSelectAuthorRole(roleCode) {
     document.listForm.roleCode.value = roleCode;
-    document.listForm.action = "<c:url value='/sec/ram/EgovRole.do'/>";
+    document.listForm.action = "<c:url value='/sec/rmt/EgovRole.do'/>";
     document.listForm.submit();     
 }
 

--- a/src/main/webapp/WEB-INF/jsp/sts/cst/EgovConectStats.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sts/cst/EgovConectStats.jsp
@@ -222,7 +222,7 @@ function fn_egov_init_date(){
                                 </div>
                                 <!--// Location -->
 
-								<form name="listForm" action="<c:url value='/sts/selectConectStats.do'/>" method="get">
+								<form name="listForm" action="<c:url value='/sts/cst/selectConectStats.do'/>" method="get">
 								
 			                    <input type="hidden" name="pdKind" value='<c:out value="${statsInfo.pdKind}"/>'/>
 			                    <input type="hidden" name="statsKind" value='<c:out value="${statsInfo.statsKind}"/>'/>

--- a/src/main/webapp/WEB-INF/jsp/sym/log/clg/EgovLoginLogList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/log/clg/EgovLoginLogList.jsp
@@ -187,7 +187,7 @@
                                 </div>
                                 <!--// Location -->
 
-								<form name="frm" id="frm" action ="<c:url value='/sym/log/SelectLoginLogList.do'/>" method="get">
+								<form name="frm" id="frm" action ="<c:url value='/sym/log/clg/SelectLoginLogList.do'/>" method="get">
 								
 								<input type="hidden" name="cal_url" value="<c:url value='/sym/cmm/EgovNormalCalPopup.do'/>" />
 
@@ -201,7 +201,7 @@
                                     <input type="text" name="searchBgnDe" id="searchBgnDe" class="f_date" maxlength="10" value="<c:out value='${searchVO.searchBgnDe}'/>" title="시작일자입력" />&nbsp ~ &nbsp
                                     <input type="text" name="searchEndDe" id="searchEndDe" class="f_date" maxlength="10" value="<c:out value='${searchVO.searchEndDe}'/>" title="종료일자입력" >
 
-                                    <a href="<c:url value='/sym/log/SelectLoginLogList.do'/>" class="item btn btn_blue_46 w_100 ml10" onclick="fn_egov_select_loginLog('1');"><spring:message code='button.inquire' /></a><!-- 조회 -->
+                                    <a href="<c:url value='/sym/log/clg/SelectLoginLogList.do'/>" class="item btn btn_blue_46 w_100 ml10" onclick="fn_egov_select_loginLog('1');"><spring:message code='button.inquire' /></a><!-- 조회 -->
                                     <a href="" class="item btn btn_blue_46 w_100" onclick="event.preventDefault(); document.frm.searchBgnDe.value=''; document.frm.searchEndDe.value='';">초기화</a><!-- 초기화 -->
                                 </div>
                                 <!--// 검색조건 -->

--- a/src/main/webapp/WEB-INF/jsp/sym/mnu/mcm/EgovMenuCreat.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/mnu/mcm/EgovMenuCreat.jsp
@@ -45,7 +45,7 @@ var imgpath = "<c:url value='/images'/>";
  * 조회 함수
  ******************************************************** */
 function selectMenuCreatTmp() {
-    document.menuCreatManageForm.action = "<c:url value='/sym/mpm/EgovMenuCreatSelect.do'/>";
+    document.menuCreatManageForm.action = "<c:url value='/sym/mnu/mcm/EgovMenuCreatSelect.do'/>";
     document.menuCreatManageForm.submit();
 }
 

--- a/src/main/webapp/WEB-INF/jsp/sym/mnu/mcm/EgovMenuCreatManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/mnu/mcm/EgovMenuCreatManage.jsp
@@ -131,7 +131,7 @@ function fn_egov_modal_remove() {
                                 </div>
                                 <!--// Location -->
 
-								<form name="menuCreatManageForm" action ="<c:url value='/sym/mpm/EgovMenuCreatManageSelect.do'/>" method="get">
+								<form name="menuCreatManageForm" action ="<c:url value='/sym/mnu/mcm/EgovMenuCreatManageSelect.do'/>" method="get">
 								
 								<input name="checkedMenuNoForDel" type="hidden" />
 								<input name="authorCode" type="hidden" />

--- a/src/main/webapp/WEB-INF/jsp/sym/mnu/mpm/EgovMenuBndeRegist.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/mnu/mpm/EgovMenuBndeRegist.jsp
@@ -53,7 +53,7 @@ function insertMenuManage() {
  ******************************************************** */
 function deleteMenuList() {
     if(confirm("메뉴일괄삭제를 하시겠습니까?. \n 메뉴정보와  프로그램목록, 프로그램 변경내역 데이타 모두  삭제 삭제처리 됩니다.")){
-        document.menuManageRegistForm.action ="<c:url value='/sym/mpm/EgovMenuBndeAllDelete.do'/>";
+        document.menuManageRegistForm.action ="<c:url value='/sym/mnu/mpm/EgovMenuBndeAllDelete.do'/>";
         document.menuManageRegistForm.submit();
     }
 }
@@ -118,7 +118,7 @@ function checkFile(){
                                 </div>
                                 <!--// Location -->
 
-								<form name="menuManageRegistForm" action ="<c:url value='/sym/mpm/EgovMenuBndeRegist.do'/>" method="post" enctype="multipart/form-data">
+								<form name="menuManageRegistForm" action ="<c:url value='/sym/mnu/mpm/EgovMenuBndeRegist.do'/>" method="post" enctype="multipart/form-data">
 								<c:if test="${not empty _csrf}"><input type="hidden" name="${_csrf.parameterName}" value="${_csrf.token}"/></c:if>
 
                                 <h1 class="tit_1">내부시스템관리</h1>

--- a/src/main/webapp/WEB-INF/jsp/sym/mnu/mpm/EgovMenuManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/mnu/mpm/EgovMenuManage.jsp
@@ -124,7 +124,7 @@ function insertMenuManage() {
  * 일괄처리 화면호출 함수
  ******************************************************** */
 /* function bndeInsertMenuManage() {
-        document.menuManageForm.action = "<c:url value='/sym/mpm/EgovMenuRegistInsert.do'/>";
+        document.menuManageForm.action = "<c:url value='/sym/mnu/mpm/EgovMenuRegistInsert.do'/>";
         document.menuManageForm.submit();   
     }
  */
@@ -144,7 +144,7 @@ function selectUpdtMenuManageDetail(menuNo) {
  * 최초조회 함수
  ******************************************************** */
 function fMenuManageSelect(){ 
-    document.menuManageForm.action = "<c:url value='/sym/mpm/EgovMenuManageSelect.do'/>";
+    document.menuManageForm.action = "<c:url value='/sym/mnu/mpm/EgovMenuManageSelect.do'/>";
     document.menuManageForm.submit();
 }
 <c:if test="${!empty resultMsg}">alert("<c:out value='${resultMsg}'/>");</c:if>
@@ -211,8 +211,8 @@ function fMenuManageSelect(){
                                     </div>
 
                                     <div class="right_col">
-                                        <a href="<c:url value='/sym/mpm/EgovMenuRegistInsert.do'/>" class="btn btn_blue_46 w_100" onclick="bndeInsertMenuManage(); return false;">일괄등록</a><!-- 일괄등록 -->
-                                        <a href="<c:url value='/sym/mpm/EgovMenuRegistInsert.do'/>" class="btn btn_blue_46 w_100" onclick="insertMenuManage(); return false;"><spring:message code="button.create" /></a><!-- 등록 -->
+                                        <a href="<c:url value='/sym/mnu/mpm/EgovMenuRegistInsert.do'/>" class="btn btn_blue_46 w_100" onclick="bndeInsertMenuManage(); return false;">일괄등록</a><!-- 일괄등록 -->
+                                        <a href="<c:url value='/sym/mnu/mpm/EgovMenuRegistInsert.do'/>" class="btn btn_blue_46 w_100" onclick="insertMenuManage(); return false;"><spring:message code="button.create" /></a><!-- 등록 -->
                                         <a href="#LINK" class="btn btn_blue_46 w_100" onclick="fDeleteMenuList(); return false;"><spring:message code="button.delete" /></a><!-- 삭제 -->
                                     </div>
                                 </div>
@@ -260,7 +260,7 @@ function fMenuManageSelect(){
                                                 </td>
                                                 <td><c:out value="${result.menuNo}"/></td>
                                                 <td>
-	                                                <a href="<c:url value='/sym/mpm/EgovMenuManageListDetailSelect.do?req_menuNo='/>${result.menuNo}" class="lnk" onclick="selectUpdtMenuManageDetail('<c:out value="${result.menuNo}"/>'); return false;">
+	                                                <a href="<c:url value='/sym/mnu/mpm/EgovMenuManageListDetailSelect.do?req_menuNo='/>${result.menuNo}" class="lnk" onclick="selectUpdtMenuManageDetail('<c:out value="${result.menuNo}"/>'); return false;">
 	                                                	<c:out value="${result.menuNm}"/>
 	                                                </a>
                                                 </td>

--- a/src/main/webapp/WEB-INF/jsp/sym/prm/EgovProgramListDetailSelectUpdt.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/prm/EgovProgramListDetailSelectUpdt.jsp
@@ -182,7 +182,7 @@ function deleteProgramListManage(form) {
 
                                     <div class="right_col btn1">
                                         <a href="" class="btn btn_blue_46 w_100" onclick="updateProgramListManage(document.getElementById('progrmManageVO'));"><spring:message code="button.save" /></a><!-- 저장 -->
-                                        <a href="<c:url value='/sym/mpm/EgovProgramListManageSelect.do'/>" class="btn btn_blue_46 w_100" onclick="selectList();"><spring:message code="button.list" /></a><!-- 목록 -->
+                                        <a href="<c:url value='/sym/prm/EgovProgramListManageSelect.do'/>" class="btn btn_blue_46 w_100" onclick="selectList();"><spring:message code="button.list" /></a><!-- 목록 -->
                                     </div>
                                 </div>
                                 <!-- // 목록/저장버튼 끝  -->

--- a/src/main/webapp/WEB-INF/jsp/sym/prm/EgovProgramListManage.jsp
+++ b/src/main/webapp/WEB-INF/jsp/sym/prm/EgovProgramListManage.jsp
@@ -200,7 +200,7 @@ function selectUpdtProgramListDetail(progrmFileNm) {
                                     </div>
 
                                     <div class="right_col">
-                                        <a href="<c:url value='/sym/mpm/EgovProgramListRegist.do'/>" class="btn btn_blue_46 w_100" onclick="insertProgramListManage();"><spring:message code="button.create" /></a><!-- 등록 -->
+                                        <a href="<c:url value='/sym/prm/EgovProgramListRegist.do'/>" class="btn btn_blue_46 w_100" onclick="insertProgramListManage();"><spring:message code="button.create" /></a><!-- 등록 -->
                                         <a href="" class="btn btn_blue_46 w_100" onclick="fDeleteProgrmManageList();"><spring:message code="button.delete" /></a><!-- 삭제 -->
                                     </div>
                                 </div>


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

여러 화면의 링크가 컨트롤러에 없는 URL을 가리킵니다. 컨트롤러 매핑은 `/sym/mnu/mpm/`인데 화면은 `/sym/mpm/`을 걸고 다른 화면들도 실제와 다른 네임스페이스를 가리킵니다.

예를 들어 `EgovMenuManage.jsp`는 다음과 같이 요청합니다.

```jsp
document.menuManageForm.action = "<c:url value='/sym/mpm/EgovMenuManageSelect.do'/>";
```

`EgovMenuManageController`의 매핑은 `/sym/mnu/mpm/EgovMenuManageSelect.do`입니다. `*.do`를 처리하는 것은 DispatcherServlet 하나뿐이고 재작성 규칙이 없어 화면에서 그 버튼을 누르면 404가 됩니다.

각 링크를 실제 매핑 경로로 맞췄습니다.

| 화면의 경로 | 실제 매핑 |
|---|---|
| `/sym/mpm/Egov*` | `/sym/mnu/mpm/`, `/sym/mnu/mcm/`, `/sym/prm/` |
| `/sec/gmt/EgovAuthorList.do` | `/sec/ram/EgovAuthorList.do` |
| `/sec/ram/EgovRole.do` | `/sec/rmt/EgovRole.do` |
| `/sts/selectConectStats.do` | `/sts/cst/selectConectStats.do` |
| `/sym/log/SelectLoginLogList.do` | `/sym/log/clg/SelectLoginLogList.do` |
| `/sym/ccm/zip/EgovCcmZipSearchPopup.do` | `/sym/cmm/EgovCcmZipSearchPopup.do` |

화면 열한 개, 열일곱 곳입니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

로컬에서 인메모리 HSQL로 애플리케이션을 띄우고 관리자로 로그인한 뒤 확인했습니다.

수정 전

```
GET /sym/mpm/EgovMenuManageSelect.do       → 404
GET /sym/mnu/mpm/EgovMenuManageSelect.do   → 200
```

수정 후 (화면이 이제 거는 경로)

```
GET /sym/mnu/mpm/EgovMenuManageSelect.do        → 200
GET /sym/mnu/mcm/EgovMenuCreatManageSelect.do   → 200
GET /sym/prm/EgovProgramListManageSelect.do     → 200
GET /sts/cst/selectConectStats.do               → 200
GET /sym/log/clg/SelectLoginLogList.do          → 200
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

링크 경로 수정이라 특정 브라우저와 무관합니다. 위 결과는 로컬 서버에 직접 요청해 확인했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

응답 코드로 확인했습니다.
