### PR TITLE
fix(mapper): 알티베이스 매퍼가 CLOB·문자 컬럼을 BLOB 핸들러에 묶던 문제 수정

### DIFF
--- a/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/cop/bbs/EgovBoard_SQL_altibase.xml
@@ -28,7 +28,7 @@
 		<result property="ntcrId" column="NTCR_ID"/>
 		<result property="ntcrNm" column="NTCR_NM"/>
 		<result property="nttNo" column="NTT_NO"/>
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
 		<result property="password" column="PASSWORD"/>
 		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
@@ -66,7 +66,7 @@
 		<result property="ntcrNm" column="NTCR_NM"/>
 		<result property="password" column="PASSWORD"/>
 		<result property="frstRegisterPnttm" column="FRST_REGIST_PNTTM"/>
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
 		<result property="useAt" column="USE_AT"/>
 		<result property="frstRegisterNm" column="FRST_REGISTER_NM"/>
 		<result property="frstRegisterId" column="FRST_REGISTER_ID"/>

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManageDtl_SQL_altibase.xml
@@ -9,8 +9,8 @@
 	  <result property="progrmFileNm" column="PROGRM_FILE_NM"/>
       <result property="rqesterNo" column="REQUST_NO"/>
       <result property="rqesterPersonId" column="RQESTER_ID"/>
-      <result property="changerqesterCn" column="CHANGE_REQUST_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
-      <result property="rqesterProcessCn" column="REQUST_PROCESS_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
+      <result property="changerqesterCn" column="CHANGE_REQUST_CN"/>
+      <result property="rqesterProcessCn" column="REQUST_PROCESS_CN"/>
       <result property="opetrId" column="OPETR_ID"/>
       <result property="processSttus" column="PROCESS_STTUS_CODE"/>
       <result property="processDe" column="PROCESS_DE"/>

--- a/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_altibase.xml
+++ b/src/main/resources/egovframework/mapper/let/sym/prm/EgovProgrmManage_SQL_altibase.xml
@@ -9,7 +9,7 @@
 		<result property="progrmFileNm" column="progrmFileNm"/>
 		<result property="progrmStrePath" column="progrmStrePath"/>
 		<result property="progrmKoreanNm" column="progrmKoreanNm"/>
-		<result property="progrmDc" column="progrmDc" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
+		<result property="progrmDc" column="progrmDc"/>
 		<result property="URL" column="URL"/>
 	</resultMap> 
  

--- a/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
+++ b/src/test/java/egovframework/test/EgovMapperTypeHandlerTest.java
@@ -1,0 +1,143 @@
+package egovframework.test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.apache.ibatis.builder.xml.XMLConfigBuilder;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.reflection.DefaultReflectorFactory;
+import org.apache.ibatis.reflection.MetaClass;
+import org.apache.ibatis.reflection.ReflectorFactory;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+/**
+ * 결과매핑의 타입핸들러가 내놓는 값은 대상 프로퍼티에 담길 수 있어야 한다.
+ *
+ * 담기지 않으면 조회 시점에 {@code argument type mismatch}로 끊긴다.
+ * 매퍼가 DB 변종마다 갈라져 있어 한 변종에서만 어긋나기 쉽다.
+ *
+ * @author 최완택
+ * @since 2026-09-02
+ */
+@DisplayName("매퍼 타입핸들러")
+class EgovMapperTypeHandlerTest {
+
+	private static final Path MAPPER_DIR = Paths.get("src/main/resources/egovframework/mapper/let");
+
+	private static final Pattern DB_TYPE = Pattern.compile("_([a-z]+)\\.xml$");
+
+	private static final ReflectorFactory REFLECTOR_FACTORY = new DefaultReflectorFactory();
+
+	@Test
+	@DisplayName("핸들러가 내놓는 타입이 프로퍼티 타입에 담긴다")
+	void resultMappingTypeHandlersFitTheirProperties() throws Exception {
+		List<String> mismatches = new ArrayList<>();
+
+		for (String dbType : dbTypes()) {
+			for (Object candidate : configurationFor(dbType).getResultMaps()) {
+				if (!(candidate instanceof ResultMap resultMap)) {
+					continue;
+				}
+				collectMismatches(dbType, resultMap, mismatches);
+			}
+		}
+
+		assertTrue(mismatches.isEmpty(), "핸들러 타입 불일치: " + mismatches);
+	}
+
+	private void collectMismatches(String dbType, ResultMap resultMap, List<String> mismatches) {
+		Class<?> resultType = resultMap.getType();
+		if (resultType == null || Map.class.isAssignableFrom(resultType)) {
+			return;
+		}
+		MetaClass metaClass = MetaClass.forClass(resultType, REFLECTOR_FACTORY);
+
+		for (ResultMapping mapping : resultMap.getResultMappings()) {
+			if (mapping.getProperty() == null || mapping.getTypeHandler() == null) {
+				continue;
+			}
+			Class<?> propertyType = metaClass.getSetterType(mapping.getProperty());
+			Class<?> handledType = handledType(mapping.getTypeHandler());
+			if (propertyType == null || handledType == null
+					|| propertyType.isPrimitive() || handledType.isPrimitive()) {
+				continue;
+			}
+			if (!propertyType.isAssignableFrom(handledType)) {
+				mismatches.add("%s %s.%s %s -> %s".formatted(dbType, resultMap.getId(),
+					mapping.getProperty(), handledType.getSimpleName(), propertyType.getSimpleName()));
+			}
+		}
+	}
+
+	/** {@code BaseTypeHandler<T>} 의 T. 알 수 없으면 null. */
+	private Class<?> handledType(TypeHandler<?> typeHandler) {
+		for (Class<?> type = typeHandler.getClass(); type != null; type = type.getSuperclass()) {
+			if (!(type.getGenericSuperclass() instanceof ParameterizedType parameterized)
+					|| parameterized.getRawType() != BaseTypeHandler.class) {
+				continue;
+			}
+			Type argument = parameterized.getActualTypeArguments()[0];
+			if (argument instanceof Class<?> resolved) {
+				return resolved;
+			}
+			if (argument instanceof GenericArrayType array && array.getGenericComponentType() == byte.class) {
+				return byte[].class;
+			}
+		}
+		return null;
+	}
+
+	private Configuration configurationFor(String dbType) throws Exception {
+		Configuration configuration;
+		try (InputStream config = getClass()
+				.getResourceAsStream("/egovframework/mapper/config/mapper-config.xml")) {
+			configuration = new XMLConfigBuilder(config).parse();
+		}
+		PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+		for (Resource mapper : resolver
+				.getResources("classpath*:/egovframework/mapper/let/**/*_" + dbType + ".xml")) {
+			try (InputStream in = mapper.getInputStream()) {
+				new XMLMapperBuilder(in, configuration, mapper.getURI().toString(),
+					configuration.getSqlFragments()).parse();
+			}
+		}
+		return configuration;
+	}
+
+	private Set<String> dbTypes() throws Exception {
+		Set<String> dbTypes = new TreeSet<>();
+		try (Stream<Path> paths = Files.walk(MAPPER_DIR)) {
+			for (Path path : paths.filter(Files::isRegularFile).toList()) {
+				Matcher matcher = DB_TYPE.matcher(path.getFileName().toString());
+				if (matcher.find()) {
+					dbTypes.add(matcher.group(1));
+				}
+			}
+		}
+		return dbTypes;
+	}
+
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

알티베이스 매퍼 다섯 곳이 `String` 프로퍼티를 `org.apache.ibatis.type.BlobTypeHandler`에 묶고 있습니다. 이 핸들러는 `BaseTypeHandler<byte[]>`라 조회 결과로 `byte[]`를 내놓습니다.

```xml
<!-- EgovBoard_SQL_altibase.xml:31 -->
<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
```

대상 프로퍼티는 다섯 개 모두 `String`입니다. 나머지 여섯 변종은 같은 자리에 핸들러를 지정하지 않습니다.

AS-IS / TO-BE — 자리마다 형제 변종에 맞췄습니다.

`NTT_CN`은 알티베이스 DDL(`all_ebt_ddl_altibase.sql:190`)에서 `CLOB`이고 오라클 변종이 `jdbcType`을 유지하므로 핸들러만 뺐습니다.

```diff
-		<result property="nttCn" column="NTT_CN" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
+		<result property="nttCn" column="NTT_CN" jdbcType="CLOB"/>
```

나머지 셋은 여섯 변종 모두 `jdbcType`도 쓰지 않아 둘 다 뺐습니다. `PROGRM_DC`는 `all_ebt_ddl_altibase.sql:362`에서 `varchar2(200)`이라 애초에 CLOB이 아닙니다.

```diff
-		<result property="progrmDc" column="progrmDc" jdbcType="CLOB" typeHandler="org.apache.ibatis.type.BlobTypeHandler"/>
+		<result property="progrmDc" column="progrmDc"/>
```

| 파일 | 프로퍼티 |
|---|---|
| `EgovBoard_SQL_altibase.xml` | `nttCn` (2) |
| `EgovProgrmManage_SQL_altibase.xml` | `progrmDc` |
| `EgovProgrmManageDtl_SQL_altibase.xml` | `changerqesterCn`, `rqesterProcessCn` |

`typeHandler` 지정은 저장소 전체에서 이 다섯 줄뿐입니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

결과매핑의 핸들러가 내놓는 타입이 대상 프로퍼티에 담기는지 DB 변종 전부에 대해 확인하는 테스트를 추가했습니다.

수정 전

```
$ mvn test -Dtest=EgovMapperTypeHandlerTest
[ERROR] EgovMapperTypeHandlerTest.resultMappingTypeHandlersFitTheirProperties:68
        핸들러 타입 불일치: [altibase BBSManageDAO.boardDetail.nttCn byte[] -> String,
        altibase progrmManageDAO.progrmManage.progrmDc byte[] -> String,
        altibase progrmManageDAO.progrmManageDtl.changerqesterCn byte[] -> String,
        altibase progrmManageDAO.progrmManageDtl.rqesterProcessCn byte[] -> String, ...]
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

수정 후

```
$ mvn test -Dtest=EgovMapperTypeHandlerTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

일곱 변종에서 결과매핑 3,348건을 검사했고 어긋나는 것은 위 다섯 곳뿐이었습니다.

전체 스위트는 `Tests run: 103, Failures: 0, Errors: 3`입니다. 남은 3건은 `Could not open JDBC Connection`으로 DB가 필요한 테스트이고, `#151`이 빌드에서 제외하려는 바로 그 셋입니다.

`pom.xml`의 surefire 설정이 `<skipTests>true</skipTests>`로 고정돼 있어 이 값을 잠시 해제하고 실행한 결과입니다. `-DskipTests=false`로는 덮어써지지 않습니다. `#151`이 머지되면 이 테스트는 빌드에서 그대로 돕니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

알티베이스 환경이 없어 브라우저로 확인하지 못했습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위와 같은 이유로 첨부하지 못했습니다.
